### PR TITLE
enable continuous  modeling

### DIFF
--- a/frontend/src/components/Data/SelectModelType.js
+++ b/frontend/src/components/Data/SelectModelType.js
@@ -15,7 +15,7 @@ class SelectModelType extends Component {
                         className="form-control mr-1 p-0"
                         id="selectmodel"
                         onChange={e => dataStore.setModelType(e.target.value)}>
-                        {dataStore.getFilteredModelTypes.map((item, i) => {
+                        {dataStore.getFilteredDatasetTypes.map((item, i) => {
                             return (
                                 <option key={i} value={item.value}>
                                     {item.name}
@@ -40,9 +40,5 @@ class SelectModelType extends Component {
 }
 SelectModelType.propTypes = {
     dataStore: PropTypes.object,
-    setModelType: PropTypes.func,
-    getEditSettings: PropTypes.func,
-    getFilteredModelTypes: PropTypes.func,
-    addDataset: PropTypes.func,
 };
 export default SelectModelType;

--- a/frontend/src/components/Main/AnalysisForm/AnalysisForm.js
+++ b/frontend/src/components/Main/AnalysisForm/AnalysisForm.js
@@ -39,7 +39,7 @@ class AnalysisForm extends Component {
                             id="dataset-type"
                             className="form-control"
                             onChange={e => mainStore.changeDatasetType(e.target.value)}
-                            value={mainStore.dataset_type}>
+                            value={mainStore.model_type}>
                             {modelTypes.map((item, i) => {
                                 return (
                                     <option key={i} value={item.value}>

--- a/frontend/src/components/Main/AnalysisForm/AnalysisFormReadOnly.js
+++ b/frontend/src/components/Main/AnalysisForm/AnalysisFormReadOnly.js
@@ -21,7 +21,7 @@ class AnalysisFormReadOnly extends Component {
                         </tr>
                         <tr>
                             <th>Model Type:</th>
-                            <td>{mainStore.getDatasetTypeName.name}</td>
+                            <td>{mainStore.getModelTypeName.name}</td>
                         </tr>
                     </tbody>
                 </table>
@@ -31,9 +31,5 @@ class AnalysisFormReadOnly extends Component {
 }
 AnalysisFormReadOnly.propTypes = {
     mainStore: PropTypes.object,
-    analysis_name: PropTypes.string,
-    analysis_description: PropTypes.string,
-    getDatasetTypeName: PropTypes.func,
-    name: PropTypes.string,
 };
 export default AnalysisFormReadOnly;

--- a/frontend/src/components/Main/DatasetList/DatasetList.js
+++ b/frontend/src/components/Main/DatasetList/DatasetList.js
@@ -11,6 +11,7 @@ class DatasetList extends Component {
     render() {
         const {dataStore} = this.props,
             datasets = toJS(dataStore.datasets);
+
         return (
             <table className="table table-bordered table-sm">
                 <thead>
@@ -29,7 +30,7 @@ class DatasetList extends Component {
                                     dataset={dataset}
                                     toggleDataset={dataStore.toggleDataset}
                                     changeDatasetProperties={dataStore.changeDatasetProperties}
-                                    dataset_type={dataStore.getDatasetType}
+                                    model_type={dataStore.getModelType}
                                 />
                             );
                         })}
@@ -41,7 +42,7 @@ class DatasetList extends Component {
                                 <DatasetsReadOnly
                                     key={index}
                                     dataset={dataset}
-                                    dataset_type={dataStore.getDatasetType}
+                                    model_type={dataStore.getModelType}
                                 />
                             );
                         })}

--- a/frontend/src/components/Main/DatasetList/Datasets.js
+++ b/frontend/src/components/Main/DatasetList/Datasets.js
@@ -1,6 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
+
 import {AdverseDirectionList, degree, background} from "../../../constants/dataConstants";
+import * as mc from "../../../constants/mainConstants";
 
 const Datasets = props => {
     return (
@@ -16,9 +18,8 @@ const Datasets = props => {
                 />
             </td>
             <td>{props.dataset.dataset_name}</td>
-            {props.dataset_type == "C" ? (
+            {props.model_type === mc.MODEL_CONTINUOUS ? (
                 <td>
-                    {" "}
                     <select
                         className="form-control"
                         onChange={e =>
@@ -38,9 +39,8 @@ const Datasets = props => {
                     </select>
                 </td>
             ) : null}
-            {props.dataset_type == "DM" ? (
+            {props.model_type === mc.MODEL_MULTI_TUMOR ? (
                 <td>
-                    {" "}
                     <select
                         as="select"
                         onChange={e =>
@@ -56,7 +56,7 @@ const Datasets = props => {
                     </select>
                 </td>
             ) : null}
-            {props.dataset_type == "DM" ? (
+            {props.model_type === mc.MODEL_MULTI_TUMOR ? (
                 <td>
                     <select
                         as="select"
@@ -82,15 +82,12 @@ const Datasets = props => {
 };
 
 Datasets.propTypes = {
-    dataStore: PropTypes.object,
     saveAdverseDirection: PropTypes.func,
-    toggleDataset: PropTypes.func,
+    toggleDataset: PropTypes.func.isRequired,
     datasets: PropTypes.array,
-    getDatasetType: PropTypes.func,
-    adverseList: PropTypes.array,
     degree: PropTypes.array,
     background: PropTypes.array,
-    dataset: PropTypes.object,
-    dataset_type: PropTypes.string,
+    dataset: PropTypes.object.isRequired,
+    model_type: PropTypes.string.isRequired,
 };
 export default Datasets;

--- a/frontend/src/components/Main/DatasetList/DatasetsReadOnly.js
+++ b/frontend/src/components/Main/DatasetList/DatasetsReadOnly.js
@@ -1,6 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 
+import * as mc from "../../../constants/mainConstants";
 import {readOnlyCheckbox} from "../../../common";
 
 const DatasetsReadOnly = props => {
@@ -8,17 +9,17 @@ const DatasetsReadOnly = props => {
         <tr>
             <td>{readOnlyCheckbox(props.dataset.enabled)}</td>
             <td>{props.dataset.dataset_name}</td>
-            {props.dataset_type === "C" ? (
+            {props.model_type === mc.MODEL_CONTINUOUS ? (
                 <td>
                     <p>{props.dataset.adverse_direction}</p>
                 </td>
             ) : null}
-            {props.dataset_type === "DM" ? (
+            {props.model_type === mc.MODEL_MULTI_TUMOR ? (
                 <td>
                     <p>{props.dataset.degree}</p>
                 </td>
             ) : null}
-            {props.dataset_type === "DM" ? (
+            {props.model_type === mc.MODEL_MULTI_TUMOR ? (
                 <td>
                     <p>{props.dataset.background}</p>
                 </td>
@@ -27,7 +28,7 @@ const DatasetsReadOnly = props => {
     );
 };
 DatasetsReadOnly.propTypes = {
-    dataset: PropTypes.object,
-    dataset_type: PropTypes.string,
+    dataset: PropTypes.object.isRequired,
+    model_type: PropTypes.string.isRequired,
 };
 export default DatasetsReadOnly;

--- a/frontend/src/components/Main/OptionsForm/OptionsForm.js
+++ b/frontend/src/components/Main/OptionsForm/OptionsForm.js
@@ -159,7 +159,7 @@ const OptionsForm = props => {
                     </select>
                 </td>
             ) : null}
-            {props.modelType == mc.MODEL_DICHOTOMOUS ? (
+            {props.modelType == mc.MODEL_DICHOTOMOUS || props.modelType == mc.MODEL_CONTINUOUS ? (
                 <td>
                     <select
                         className="form-control"

--- a/frontend/src/components/Main/OptionsForm/OptionsForm.js
+++ b/frontend/src/components/Main/OptionsForm/OptionsForm.js
@@ -15,7 +15,7 @@ import {
 const OptionsForm = props => {
     return (
         <tr className="form-group">
-            {props.dataset_type === mc.MODEL_CONTINUOUS ? (
+            {props.modelType === mc.MODEL_CONTINUOUS ? (
                 <td>
                     <select
                         className="form-control"
@@ -31,7 +31,7 @@ const OptionsForm = props => {
                     </select>
                 </td>
             ) : null}
-            {props.dataset_type != mc.MODEL_CONTINUOUS ? (
+            {props.modelType != mc.MODEL_CONTINUOUS ? (
                 <td>
                     <select
                         className="form-control"
@@ -58,7 +58,7 @@ const OptionsForm = props => {
                     }
                 />
             </td>
-            {props.dataset_type === mc.MODEL_CONTINUOUS ? (
+            {props.modelType === mc.MODEL_CONTINUOUS ? (
                 <td>
                     <input
                         type="number"
@@ -84,7 +84,7 @@ const OptionsForm = props => {
                     }
                 />
             </td>
-            {props.dataset_type === mc.MODEL_NESTED ? (
+            {props.modelType === mc.MODEL_NESTED ? (
                 <td>
                     <select
                         className="form-control"
@@ -107,7 +107,7 @@ const OptionsForm = props => {
                 </td>
             ) : null}
 
-            {props.dataset_type === mc.MODEL_CONTINUOUS ? (
+            {props.modelType === mc.MODEL_CONTINUOUS ? (
                 <td>
                     <select
                         className="form-control"
@@ -125,7 +125,7 @@ const OptionsForm = props => {
                     </select>
                 </td>
             ) : null}
-            {props.dataset_type === mc.MODEL_CONTINUOUS ? (
+            {props.modelType === mc.MODEL_CONTINUOUS ? (
                 <td>
                     <select
                         className="form-control"
@@ -141,7 +141,7 @@ const OptionsForm = props => {
                     </select>
                 </td>
             ) : null}
-            {props.dataset_type === mc.MODEL_CONTINUOUS ? (
+            {props.modelType === mc.MODEL_CONTINUOUS ? (
                 <td>
                     <select
                         className="form-control"
@@ -159,7 +159,7 @@ const OptionsForm = props => {
                     </select>
                 </td>
             ) : null}
-            {props.dataset_type != mc.MODEL_DICHOTOMOUS ? (
+            {props.modelType == mc.MODEL_DICHOTOMOUS ? (
                 <td>
                     <select
                         className="form-control"
@@ -169,7 +169,7 @@ const OptionsForm = props => {
                     </select>
                 </td>
             ) : null}
-            {props.dataset_type === mc.MODEL_NESTED ? (
+            {props.modelType === mc.MODEL_NESTED ? (
                 <td>
                     <input
                         type="number"
@@ -181,7 +181,7 @@ const OptionsForm = props => {
                     />
                 </td>
             ) : null}
-            {props.dataset_type === mc.MODEL_NESTED ? (
+            {props.modelType === mc.MODEL_NESTED ? (
                 <td>
                     <select
                         className="form-control"
@@ -216,13 +216,12 @@ const OptionsForm = props => {
 
 OptionsForm.propTypes = {
     optionsStore: PropTypes.string,
-    optionsLis: PropTypes.array,
-    idx: PropTypes.number,
-    dataset_type: PropTypes.string,
+    idx: PropTypes.number.isRequired,
+    modelType: PropTypes.string.isRequired,
     onChange: PropTypes.func,
-    saveOptions: PropTypes.func,
-    deleteOptions: PropTypes.func,
-    options: PropTypes.object,
+    saveOptions: PropTypes.func.isRequired,
+    deleteOptions: PropTypes.func.isRequired,
+    options: PropTypes.object.isRequired,
     bmr_value: PropTypes.number,
     tail_probability: PropTypes.number,
     litter_specific_covariate: PropTypes.string,

--- a/frontend/src/components/Main/OptionsForm/OptionsForm.js
+++ b/frontend/src/components/Main/OptionsForm/OptionsForm.js
@@ -1,5 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
+
+import * as mc from "../../../constants/mainConstants";
 import {
     bmr_type,
     other_bmr_type,
@@ -8,13 +10,12 @@ import {
     variance,
     polynomial_restriction,
     bootstrap_seed,
-    datasetType,
 } from "../../../constants/optionsConstants";
 
 const OptionsForm = props => {
     return (
         <tr className="form-group">
-            {props.dataset_type === datasetType.Continuous ? (
+            {props.dataset_type === mc.MODEL_CONTINUOUS ? (
                 <td>
                     <select
                         className="form-control"
@@ -30,7 +31,7 @@ const OptionsForm = props => {
                     </select>
                 </td>
             ) : null}
-            {props.dataset_type != datasetType.Continuous ? (
+            {props.dataset_type != mc.MODEL_CONTINUOUS ? (
                 <td>
                     <select
                         className="form-control"
@@ -57,7 +58,7 @@ const OptionsForm = props => {
                     }
                 />
             </td>
-            {props.dataset_type === datasetType.Continuous ? (
+            {props.dataset_type === mc.MODEL_CONTINUOUS ? (
                 <td>
                     <input
                         type="number"
@@ -83,7 +84,7 @@ const OptionsForm = props => {
                     }
                 />
             </td>
-            {props.dataset_type === datasetType.Nested ? (
+            {props.dataset_type === mc.MODEL_NESTED ? (
                 <td>
                     <select
                         className="form-control"
@@ -106,7 +107,7 @@ const OptionsForm = props => {
                 </td>
             ) : null}
 
-            {props.dataset_type === datasetType.Continuous ? (
+            {props.dataset_type === mc.MODEL_CONTINUOUS ? (
                 <td>
                     <select
                         className="form-control"
@@ -124,7 +125,7 @@ const OptionsForm = props => {
                     </select>
                 </td>
             ) : null}
-            {props.dataset_type === datasetType.Continuous ? (
+            {props.dataset_type === mc.MODEL_CONTINUOUS ? (
                 <td>
                     <select
                         className="form-control"
@@ -140,7 +141,7 @@ const OptionsForm = props => {
                     </select>
                 </td>
             ) : null}
-            {props.dataset_type === datasetType.Continuous ? (
+            {props.dataset_type === mc.MODEL_CONTINUOUS ? (
                 <td>
                     <select
                         className="form-control"
@@ -158,7 +159,7 @@ const OptionsForm = props => {
                     </select>
                 </td>
             ) : null}
-            {props.dataset_type != datasetType.Dichotomous ? (
+            {props.dataset_type != mc.MODEL_DICHOTOMOUS ? (
                 <td>
                     <select
                         className="form-control"
@@ -168,7 +169,7 @@ const OptionsForm = props => {
                     </select>
                 </td>
             ) : null}
-            {props.dataset_type === datasetType.Nested ? (
+            {props.dataset_type === mc.MODEL_NESTED ? (
                 <td>
                     <input
                         type="number"
@@ -180,7 +181,7 @@ const OptionsForm = props => {
                     />
                 </td>
             ) : null}
-            {props.dataset_type === datasetType.Nested ? (
+            {props.dataset_type === mc.MODEL_NESTED ? (
                 <td>
                     <select
                         className="form-control"

--- a/frontend/src/components/Main/OptionsForm/OptionsFormList.js
+++ b/frontend/src/components/Main/OptionsForm/OptionsFormList.js
@@ -44,7 +44,7 @@ class OptionsFormList extends Component {
                                             key={id}
                                             idx={id}
                                             options={options}
-                                            dataset_type={optionsStore.getDatasetType}
+                                            modelType={optionsStore.getModelType}
                                             deleteOptions={optionsStore.deleteOptions}
                                             saveOptions={optionsStore.saveOptions}
                                         />

--- a/frontend/src/components/Output/BenchmarkDose.js
+++ b/frontend/src/components/Output/BenchmarkDose.js
@@ -2,10 +2,13 @@ import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
 
+import {getPValue} from "../../constants/outputConstants";
+
 @observer
 class BenchmarkDose extends Component {
     render() {
         const {store} = this.props,
+            dataset = store.selectedDataset,
             results = store.selectedModel.results;
 
         return (
@@ -34,7 +37,7 @@ class BenchmarkDose extends Component {
                     </tr>
                     <tr>
                         <td>P Value</td>
-                        <td>{results.gof.p_value}</td>
+                        <td>{getPValue(dataset.model_type, results)}</td>
                     </tr>
                 </tbody>
             </table>

--- a/frontend/src/components/Output/CDFPlot.js
+++ b/frontend/src/components/Output/CDFPlot.js
@@ -50,8 +50,7 @@ const layout = {
 @observer
 class CDFPlot extends Component {
     render() {
-        const {store} = this.props,
-            cdf = toJS(store.selectedModel.results.fit.bmd_dist),
+        const cdf = toJS(this.props.cdf),
             data = {
                 x: cdf[0],
                 y: cdf[1],
@@ -64,7 +63,7 @@ class CDFPlot extends Component {
 }
 
 CDFPlot.propTypes = {
-    store: PropTypes.object,
+    cdf: PropTypes.array,
 };
 
 export default CDFPlot;

--- a/frontend/src/components/Output/CDFTable.js
+++ b/frontend/src/components/Output/CDFTable.js
@@ -2,13 +2,11 @@ import _ from "lodash";
 import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
-import {toJS} from "mobx";
 
 @observer
 class CDFTable extends Component {
     render() {
-        const {store} = this.props,
-            data = toJS(store.selectedModel.results.fit.bmd_dist);
+        const {bmd_dist} = this.props;
 
         return (
             <table className="table table-bordered table-sm">
@@ -22,11 +20,11 @@ class CDFTable extends Component {
                     </tr>
                 </thead>
                 <tbody>
-                    {_.range(data[0].length).map(i => {
+                    {_.range(bmd_dist[0].length).map(i => {
                         return (
                             <tr key={i}>
-                                <td>{data[1][i]}</td>
-                                <td>{data[0][i]}</td>
+                                <td>{bmd_dist[1][i]}</td>
+                                <td>{bmd_dist[0][i]}</td>
                             </tr>
                         );
                     })}
@@ -36,7 +34,7 @@ class CDFTable extends Component {
     }
 }
 CDFTable.propTypes = {
-    store: PropTypes.object,
+    bmd_dist: PropTypes.array,
 };
 
 export default CDFTable;

--- a/frontend/src/components/Output/CSLoglikelihoods.js
+++ b/frontend/src/components/Output/CSLoglikelihoods.js
@@ -1,12 +1,11 @@
 import React, {Component} from "react";
-import {inject, observer} from "mobx-react";
+import {observer} from "mobx-react";
 import PropTypes from "prop-types";
 
-@inject("outputStore")
 @observer
 class CSLoglikelihoods extends Component {
     render() {
-        const {outputStore} = this.props;
+        const {results} = this.props;
         return (
             <table className="table table-bordered table-sm">
                 <thead className="table-primary">
@@ -21,24 +20,16 @@ class CSLoglikelihoods extends Component {
                     </tr>
                 </thead>
                 <tbody>
-                    {outputStore.getLoglikelihoods.map((row, index) => {
-                        return (
-                            <tr key={index}>
-                                <td>{row.model}</td>
-                                <td>{row.loglikelihood}</td>
-                                <td>{row.n_parms}</td>
-                                <td>{row.aic}</td>
-                            </tr>
-                        );
-                    })}
+                    <tr>
+                        <td colSpan={4}>ADD - {results.aic}</td>
+                    </tr>
                 </tbody>
             </table>
         );
     }
 }
 CSLoglikelihoods.propTypes = {
-    outputStore: PropTypes.object,
-    getLoglikelihoods: PropTypes.func,
+    results: PropTypes.object,
 };
 
 export default CSLoglikelihoods;

--- a/frontend/src/components/Output/CSTestofInterest.js
+++ b/frontend/src/components/Output/CSTestofInterest.js
@@ -1,12 +1,11 @@
 import React, {Component} from "react";
-import {inject, observer} from "mobx-react";
+import {observer} from "mobx-react";
 import PropTypes from "prop-types";
 
-@inject("outputStore")
 @observer
 class CSTestofInterest extends Component {
     render() {
-        const {outputStore} = this.props;
+        const {results} = this.props;
         return (
             <table className="table table-bordered table-sm">
                 <thead className="table-primary">
@@ -21,23 +20,15 @@ class CSTestofInterest extends Component {
                     </tr>
                 </thead>
                 <tbody>
-                    {outputStore.getTestofInterest.map((row, index) => {
-                        return (
-                            <tr key={index}>
-                                <td>{row.test_number}</td>
-                                <td>{row.deviance}</td>
-                                <td>{row.df}</td>
-                                <td>{row.p_value}</td>
-                            </tr>
-                        );
-                    })}
+                    <tr>
+                        <td colSpan={4}>ADD - {results.aic}</td>
+                    </tr>
                 </tbody>
             </table>
         );
     }
 }
 CSTestofInterest.propTypes = {
-    outputStore: PropTypes.object,
-    getTestofInterest: PropTypes.func,
+    results: PropTypes.object,
 };
 export default CSTestofInterest;

--- a/frontend/src/components/Output/GoodnessFit.js
+++ b/frontend/src/components/Output/GoodnessFit.js
@@ -3,7 +3,7 @@ import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
 
-import {model_type} from "../../constants/dataConstants";
+import * as dc from "../../constants/dataConstants";
 
 const continuousRow = function(row, index) {
         return (
@@ -33,10 +33,10 @@ const continuousRow = function(row, index) {
         );
     },
     getRows = function(output, model) {
-        if (output.dataset.model_type === model_type.Continuous_Summarized) {
+        if (output.dataset.model_type === dc.DATA_CONTINUOUS_SUMMARY) {
             // TODO - fix
             return output.results.gof;
-        } else if (output.dataset.model_type === model_type.Dichotomous) {
+        } else if (output.dataset.model_type === dc.DATA_DICHOTOMOUS) {
             return _.zip(
                 output.dataset.doses,
                 output.dataset.ns,
@@ -57,16 +57,16 @@ const continuousRow = function(row, index) {
         }
     },
     getRowFunc = function(output) {
-        if (output.dataset.model_type === model_type.Continuous_Summarized) {
+        if (output.dataset.model_type === dc.DATA_CONTINUOUS_SUMMARY) {
             return continuousRow;
-        } else if (output.dataset.model_type === model_type.Dichotomous) {
+        } else if (output.dataset.model_type === dc.DATA_DICHOTOMOUS) {
             return dichotomousRow;
         } else {
-            throw `Unknown model type ${model_type}`;
+            throw `Unknown model type ${output.dataset.model_type}`;
         }
     },
     goodnessFitHeaders = {
-        [model_type.Continuous_Summarized]: [
+        [dc.DATA_CONTINUOUS_SUMMARY]: [
             "Dose",
             "Observed Mean",
             "Observed SD",
@@ -77,7 +77,7 @@ const continuousRow = function(row, index) {
             "Size",
             "Scaled Residual",
         ],
-        [model_type.Dichotomous]: [
+        [dc.DATA_DICHOTOMOUS]: [
             "Dose",
             "Estimated probability",
             "Expected",

--- a/frontend/src/components/Output/ModelDetailModal.js
+++ b/frontend/src/components/Output/ModelDetailModal.js
@@ -15,12 +15,18 @@ import CSLoglikelihoods from "./CSLoglikelihoods";
 import ResponsePlot from "./ResponsePlot";
 import CSTestofInterest from "./CSTestofInterest";
 
+import * as dc from "../../constants/dataConstants";
+
 @inject("outputStore")
 @observer
 class ModelDetailModal extends Component {
     render() {
-        const {outputStore} = this.props;
-        if (outputStore.selectedModel === undefined) {
+        const {outputStore} = this.props,
+            output = outputStore.getCurrentOutput,
+            dataset = output.dataset,
+            model = outputStore.selectedModel;
+
+        if (model === undefined) {
             return null;
         }
         return (
@@ -31,10 +37,7 @@ class ModelDetailModal extends Component {
                 aria-labelledby="contained-modal-title-vcenter"
                 centered>
                 <Modal.Header>
-                    <Modal.Title id="contained-modal-title-vcenter">
-                        {" "}
-                        {outputStore.selectedModel.model_name} - Details
-                    </Modal.Title>
+                    <Modal.Title id="contained-modal-title-vcenter">{model.model_name}</Modal.Title>
                     <button
                         className="btn btn-danger"
                         style={{float: "right"}}
@@ -63,28 +66,30 @@ class ModelDetailModal extends Component {
                             <ModelParameters store={outputStore} />
                         </Col>
                     </Row>
-                    <Row>
-                        <Col xs={12}>
-                            <GoodnessFit store={outputStore} />
-                        </Col>
-                    </Row>
-                    {outputStore.getCurrentOutput.dataset.model_type == "CS" ? (
+                    {dataset.model_type == dc.DATA_DICHOTOMOUS ? (
+                        <Row>
+                            <Col xs={12}>
+                                <GoodnessFit store={outputStore} />
+                            </Col>
+                        </Row>
+                    ) : null}
+                    {dataset.model_type == dc.DATA_CONTINUOUS_SUMMARY ? (
                         <Row>
                             <Col xs={4}>
-                                <CSLoglikelihoods />
+                                <CSLoglikelihoods results={model.results} />
                             </Col>
                             <Col xs={4}>
-                                <CSTestofInterest />
+                                <CSTestofInterest results={model.results} />
                             </Col>
                         </Row>
                     ) : null}
                     <Row>
                         <Col xs={4}>
-                            <CDFTable store={outputStore} />
+                            <CDFTable bmd_dist={model.results.fit.bmd_dist} />
                         </Col>
                         <Col>
                             <ResponsePlot />
-                            <CDFPlot store={outputStore} />
+                            <CDFPlot cdf={model.results.fit.bmd_dist} />
                         </Col>
                     </Row>
                 </Modal.Body>

--- a/frontend/src/components/Output/ResultsTable.js
+++ b/frontend/src/components/Output/ResultsTable.js
@@ -1,13 +1,15 @@
+import {inject, observer} from "mobx-react";
 import React, {Component} from "react";
 import PropTypes from "prop-types";
 
-import {inject, observer} from "mobx-react";
+import {getPValue} from "../../constants/outputConstants";
 
 @inject("outputStore")
 @observer
 class ResultsTable extends Component {
     render() {
-        const store = this.props.outputStore;
+        const store = this.props.outputStore,
+            dataset = store.selectedDataset;
         return (
             <table className="table table-bordered result table-sm">
                 <thead>
@@ -41,7 +43,7 @@ class ResultsTable extends Component {
                                 <td>{model.results.bmdl}</td>
                                 <td>{model.results.bmdu}</td>
                                 <td>{model.results.aic}</td>
-                                <td>{model.results.gof.p_value}</td>
+                                <td>{getPValue(dataset.model_type, model.results)}</td>
                             </tr>
                         );
                     })}

--- a/frontend/src/constants/dataConstants.js
+++ b/frontend/src/constants/dataConstants.js
@@ -1,34 +1,40 @@
-const modelTypes = [
-        {value: "CS", name: "Summarized"},
-        {value: "CI", name: "Individual"},
-        {value: "DM", name: "Dichotomous"},
-        {value: "N", name: "Nested"},
+import * as mc from "./mainConstants";
+
+const DATA_CONTINUOUS_SUMMARY = "CS",
+    DATA_CONTINUOUS_INDIVIDUAL = "I",
+    DATA_DICHOTOMOUS = "DM",
+    DATA_NESTED = "N",
+    datasetTypes = [
+        {value: DATA_CONTINUOUS_SUMMARY, name: "Summarized"},
+        {value: DATA_CONTINUOUS_INDIVIDUAL, name: "Individual"},
+        {value: DATA_DICHOTOMOUS, name: "Dichotomous"},
+        {value: DATA_NESTED, name: "Nested"},
     ],
     columns = {
-        CS: ["doses", "ns", "means", "stdevs"],
-        CI: ["doses", "responses"],
-        DM: ["doses", "ns", "incidences"],
-        N: ["doses", "litter_sizes", "incidences", "litter_specific_covariates"],
+        [DATA_CONTINUOUS_SUMMARY]: ["doses", "ns", "means", "stdevs"],
+        [DATA_CONTINUOUS_INDIVIDUAL]: ["doses", "responses"],
+        [DATA_DICHOTOMOUS]: ["doses", "ns", "incidences"],
+        [DATA_NESTED]: ["doses", "litter_sizes", "incidences", "litter_specific_covariates"],
     },
     columnNames = {
-        CS: {
+        [DATA_CONTINUOUS_SUMMARY]: {
             doses: "Dose",
             ns: "N",
             means: "Mean",
-            stdevs: "St. Dev.",
+            stdevs: "Std. Dev.",
         },
-        CI: {
+        [DATA_CONTINUOUS_INDIVIDUAL]: {
             doses: "Dose",
             responses: "Response",
         },
-        DM: {
+        [DATA_DICHOTOMOUS]: {
             doses: "Dose",
             ns: "N",
             incidences: "Incidence",
         },
-        N: {
+        [DATA_NESTED]: {
             doses: "Dose",
-            litter_sizes: "LItter Size",
+            litter_sizes: "Litter Size",
             incidences: "Incidence",
             litter_specific_covariates: "Litter Specific Covariate",
         },
@@ -37,41 +43,35 @@ const modelTypes = [
         doses: "Dose",
         ns: "N",
         means: "Mean",
-        stdevs: "St. Dev.",
+        stdevs: "Std. Dev.",
         responses: "Response",
         incidences: "Incidence",
         litter_sizes: "Litter Size",
         litter_specific_covariates: "Litter Specific Covariate",
     },
     datasetForm = {
-        CS: {
+        [DATA_CONTINUOUS_SUMMARY]: {
             doses: [0, 7, 37, 186],
             ns: [25, 25, 25, 24],
             means: [55.8, 52.9, 64.8, 119.9],
             stdevs: [12.5, 15.4, 17.4, 32.5],
             adverse_direction: "automatic",
         },
-        CI: {
+        [DATA_CONTINUOUS_INDIVIDUAL]: {
             doses: ["", "", "", "", ""],
             responses: ["", "", "", "", ""],
         },
-        DM: {
+        [DATA_DICHOTOMOUS]: {
             doses: [0, 0.46, 1.39, 4.17, 12.5],
             ns: [9, 9, 11, 10, 7],
             incidences: [0, 0, 3, 2, 3],
         },
-        N: {
+        [DATA_NESTED]: {
             doses: ["", "", "", "", ""],
             litter_sizes: ["", "", "", "", ""],
             incidences: ["", "", "", "", ""],
             litter_specific_covariates: ["", "", "", "", ""],
         },
-    },
-    datasetNamesHeaders = {
-        C: ["Enable", "Datasets", "Adverse Direction"],
-        D: ["Enable", "Datasets"],
-        DM: ["Enable", "Datasets", "Degree", "Background"],
-        N: ["Enable", "Datasets"],
     },
     AdverseDirectionList = [
         {value: "automatic", name: "Automatic"},
@@ -131,10 +131,10 @@ const modelTypes = [
         autosize: true,
     },
     yAxisTitle = {
-        CI: "responses",
-        CS: "means",
-        DM: "incidences",
-        N: "incidences",
+        [DATA_CONTINUOUS_SUMMARY]: "responses",
+        [DATA_CONTINUOUS_INDIVIDUAL]: "means",
+        [DATA_DICHOTOMOUS]: "incidences",
+        [DATA_NESTED]: "incidences",
     },
     model_type = {
         Continuous_Summarized: "CS",
@@ -144,12 +144,11 @@ const modelTypes = [
     };
 
 export {
-    modelTypes,
+    datasetTypes,
     columns,
     columnNames,
     columnHeaders,
     datasetForm,
-    datasetNamesHeaders,
     AdverseDirectionList,
     degree,
     background,

--- a/frontend/src/constants/dataConstants.js
+++ b/frontend/src/constants/dataConstants.js
@@ -1,6 +1,6 @@
 const modelTypes = [
-        {value: "CS", name: "Continuous Summarized"},
-        {value: "CI", name: "Continuous Individual"},
+        {value: "CS", name: "Summarized"},
+        {value: "CI", name: "Individual"},
         {value: "DM", name: "Dichotomous"},
         {value: "N", name: "Nested"},
     ],

--- a/frontend/src/constants/dataConstants.js
+++ b/frontend/src/constants/dataConstants.js
@@ -1,15 +1,25 @@
 import * as mc from "./mainConstants";
 
-const DATA_CONTINUOUS_SUMMARY = "CS",
+export const DATA_CONTINUOUS_SUMMARY = "CS",
     DATA_CONTINUOUS_INDIVIDUAL = "I",
     DATA_DICHOTOMOUS = "DM",
     DATA_NESTED = "N",
-    datasetTypes = [
-        {value: DATA_CONTINUOUS_SUMMARY, name: "Summarized"},
-        {value: DATA_CONTINUOUS_INDIVIDUAL, name: "Individual"},
-        {value: DATA_DICHOTOMOUS, name: "Dichotomous"},
-        {value: DATA_NESTED, name: "Nested"},
-    ],
+    datasetTypesByModelType = function(modelType) {
+        switch (modelType) {
+            case mc.MODEL_DICHOTOMOUS:
+            case mc.MODEL_MULTI_TUMOR:
+                return [{value: DATA_DICHOTOMOUS, name: "Dichotomous"}];
+            case mc.MODEL_CONTINUOUS:
+                return [
+                    {value: DATA_CONTINUOUS_SUMMARY, name: "Summarized"},
+                    {value: DATA_CONTINUOUS_INDIVIDUAL, name: "Individual"},
+                ];
+            case mc.MODEL_NESTED:
+                return [{value: DATA_NESTED, name: "Nested"}];
+            default:
+                throw `Unknown modelType: ${modelType}`;
+        }
+    },
     columns = {
         [DATA_CONTINUOUS_SUMMARY]: ["doses", "ns", "means", "stdevs"],
         [DATA_CONTINUOUS_INDIVIDUAL]: ["doses", "responses"],
@@ -135,24 +145,4 @@ const DATA_CONTINUOUS_SUMMARY = "CS",
         [DATA_CONTINUOUS_INDIVIDUAL]: "means",
         [DATA_DICHOTOMOUS]: "incidences",
         [DATA_NESTED]: "incidences",
-    },
-    model_type = {
-        Continuous_Summarized: "CS",
-        Continuous_Individual: "CI",
-        Dichotomous: "DM",
-        Nested: "N",
     };
-
-export {
-    datasetTypes,
-    columns,
-    columnNames,
-    columnHeaders,
-    datasetForm,
-    AdverseDirectionList,
-    degree,
-    background,
-    scatter_plot_layout,
-    yAxisTitle,
-    model_type,
-};

--- a/frontend/src/constants/mainConstants.js
+++ b/frontend/src/constants/mainConstants.js
@@ -1,15 +1,10 @@
-// TODO - add back other model types
-const modelTypes = [
-    // {name: "Continuous", value: "C"},
-    {name: "Dichotomous", value: "D"},
-    // {name: "Dichotomous-Multi-tumor (MS_Combo)", value: "DM"},
-    // {name: "Dichotomous-Nested", value: "N"},
-];
-
-const datasetType = {
-    Nested: "N",
-    Continuous: "C",
-    Dichotomous: "DM",
-};
-
-export {modelTypes, datasetType};
+export const MODEL_CONTINUOUS = "C",
+    MODEL_DICHOTOMOUS = "D",
+    MODEL_NESTED = "N",
+    MODEL_MULTI_TUMOR = "DM",
+    modelTypes = [
+        {name: "Continuous", value: MODEL_CONTINUOUS},
+        {name: "Dichotomous", value: MODEL_DICHOTOMOUS},
+        // {name: "Dichotomous-Multi-tumor (MS_Combo)", value: MODEL_MULTI_TUMOR},
+        // {name: "Dichotomous-Nested", value: MODEL_NESTED},
+    ];

--- a/frontend/src/constants/mainConstants.js
+++ b/frontend/src/constants/mainConstants.js
@@ -1,4 +1,5 @@
-export const MODEL_CONTINUOUS = "C",
+export const VERSION_330 = "BMDS330",
+    MODEL_CONTINUOUS = "C",
     MODEL_DICHOTOMOUS = "D",
     MODEL_NESTED = "N",
     MODEL_MULTI_TUMOR = "DM",
@@ -7,4 +8,10 @@ export const MODEL_CONTINUOUS = "C",
         {name: "Dichotomous", value: MODEL_DICHOTOMOUS},
         // {name: "Dichotomous-Multi-tumor (MS_Combo)", value: MODEL_MULTI_TUMOR},
         // {name: "Dichotomous-Nested", value: MODEL_NESTED},
-    ];
+    ],
+    datasetNamesHeaders = {
+        [MODEL_CONTINUOUS]: ["Enable", "Datasets", "Adverse Direction"],
+        [MODEL_DICHOTOMOUS]: ["Enable", "Datasets"],
+        [MODEL_MULTI_TUMOR]: ["Enable", "Datasets", "Degree", "Background"],
+        [MODEL_NESTED]: ["Enable", "Datasets"],
+    };

--- a/frontend/src/constants/modelConstants.js
+++ b/frontend/src/constants/modelConstants.js
@@ -476,8 +476,4 @@ const model = {
     DichotomousHill: "DichotomousHill",
 };
 
-const datasetType = {
-    Nested: "N",
-};
-
-export {modelsList, modelHeaders, nestedHeaders, model, datasetType};
+export {modelsList, modelHeaders, nestedHeaders, model};

--- a/frontend/src/constants/optionsConstants.js
+++ b/frontend/src/constants/optionsConstants.js
@@ -85,11 +85,6 @@ const bootstrap_seed = [
     {value: "Automatic", name: "Automatic"},
     {value: "User_Specified", name: "User Specified"},
 ];
-const datasetType = {
-    Nested: "N",
-    Continuous: "C",
-    Dichotomous: "DM",
-};
 export {
     headers,
     options,
@@ -100,5 +95,4 @@ export {
     variance,
     polynomial_restriction,
     bootstrap_seed,
-    datasetType,
 };

--- a/frontend/src/constants/outputConstants.js
+++ b/frontend/src/constants/outputConstants.js
@@ -1,96 +1,98 @@
-const infoTable = {
-    model_name: {label: "Model Name", value: ""},
-    dataset_name: {label: "Dataset Name", value: ""},
-    dose_response_model: {label: "Dose Response Model", value: ""},
-};
+import * as dc from "./dataConstants";
 
-const model_options = {
-    CS: [
-        {label: "BMR Type", name: "bmrType", value: ""},
-        {label: "BMRF", name: "bmr", value: ""},
-        {label: "Tail Probability", name: "tailProb", value: ""},
-        {label: "Confidence Level", name: "alpha", value: ""},
-        {label: "Distribution Type", name: "distType", value: ""},
-        {label: "Variance Type", name: "varType", value: ""},
-    ],
-    DM: [
-        {label: "Risk Type", name: "bmrType", value: ""},
-        {label: "BMR", name: "bmr", value: ""},
-        {label: "Confidence Level", name: "alpha", value: ""},
-        {label: "Background", name: "background", value: ""},
-    ],
-};
-
-const bmrType = {
-    1: "Abs. Dev",
-    2: "Std. Dev",
-    3: "Rel. Dev",
-    4: "Point Estimate",
-    5: "Hybrid-Extra Risk",
-};
-const distType = {
-    1: "Normal",
-    2: "Log-Normal",
-};
-const varType = {
-    1: "Constant",
-    2: "Non-Constant",
-};
-
-const modelData = {
-    dependent_variable: {label: "Dependent Variable", value: "Dose"},
-    independent_variable: {label: "Independent Variable", value: "Mean"},
-    number_of_observations: {label: "Number of Observations", value: ""},
-    adverse_direction: {label: "Adverse Direction", value: ""},
-};
-
-const adverse_direction = {
-    0: "Automatic",
-    1: "Up",
-    2: "Down",
-};
-
-const layout = {
-    showlegend: true,
-    title: {
-        text: "Response Plot",
-        font: {
-            family: "Courier New, monospace",
-            size: 12,
-        },
-        xref: "paper",
+export const infoTable = {
+        model_name: {label: "Model Name", value: ""},
+        dataset_name: {label: "Dataset Name", value: ""},
+        dose_response_model: {label: "Dose Response Model", value: ""},
     },
-    xaxis: {
-        linecolor: "black",
-        linewidth: 1,
-        mirror: true,
+    model_options = {
+        CS: [
+            {label: "BMR Type", name: "bmrType", value: ""},
+            {label: "BMRF", name: "bmr", value: ""},
+            {label: "Tail Probability", name: "tailProb", value: ""},
+            {label: "Confidence Level", name: "alpha", value: ""},
+            {label: "Distribution Type", name: "distType", value: ""},
+            {label: "Variance Type", name: "varType", value: ""},
+        ],
+        DM: [
+            {label: "Risk Type", name: "bmrType", value: ""},
+            {label: "BMR", name: "bmr", value: ""},
+            {label: "Confidence Level", name: "alpha", value: ""},
+            {label: "Background", name: "background", value: ""},
+        ],
+    },
+    bmrType = {
+        1: "Abs. Dev",
+        2: "Std. Dev",
+        3: "Rel. Dev",
+        4: "Point Estimate",
+        5: "Hybrid-Extra Risk",
+    },
+    distType = {
+        1: "Normal",
+        2: "Log-Normal",
+    },
+    varType = {
+        1: "Constant",
+        2: "Non-Constant",
+    },
+    modelData = {
+        dependent_variable: {label: "Dependent Variable", value: "Dose"},
+        independent_variable: {label: "Independent Variable", value: "Mean"},
+        number_of_observations: {label: "Number of Observations", value: ""},
+        adverse_direction: {label: "Adverse Direction", value: ""},
+    },
+    adverse_direction = {
+        0: "Automatic",
+        1: "Up",
+        2: "Down",
+    },
+    layout = {
+        showlegend: true,
         title: {
-            text: "Dose (mg/kg-day)",
+            text: "Response Plot",
             font: {
                 family: "Courier New, monospace",
                 size: 12,
-                color: "#7f7f7f",
+            },
+            xref: "paper",
+        },
+        xaxis: {
+            linecolor: "black",
+            linewidth: 1,
+            mirror: true,
+            title: {
+                text: "Dose (mg/kg-day)",
+                font: {
+                    family: "Courier New, monospace",
+                    size: 12,
+                    color: "#7f7f7f",
+                },
             },
         },
-    },
-    yaxis: {
-        linecolor: "black",
-        linewidth: 1,
-        mirror: true,
-        title: {
-            text: "Response (mg/dL)",
-            font: {
-                family: "Courier New, monospace",
-                size: 12,
-                color: "#7f7f7f",
+        yaxis: {
+            linecolor: "black",
+            linewidth: 1,
+            mirror: true,
+            title: {
+                text: "Response (mg/dL)",
+                font: {
+                    family: "Courier New, monospace",
+                    size: 12,
+                    color: "#7f7f7f",
+                },
             },
         },
+        plot_bgcolor: "",
+        paper_bgcolor: "#eee",
+        width: 400,
+        height: 400,
+        autosize: true,
     },
-    plot_bgcolor: "",
-    paper_bgcolor: "#eee",
-    width: 400,
-    height: 400,
-    autosize: true,
-};
-
-export {infoTable, model_options, bmrType, distType, varType, modelData, adverse_direction, layout};
+    getPValue = function(dataType, results) {
+        if (dataType === dc.DATA_DICHOTOMOUS) {
+            return results.gof.p_value;
+        } else {
+            return -999;
+        }
+    };

--- a/frontend/src/stores/DataStore.js
+++ b/frontend/src/stores/DataStore.js
@@ -1,12 +1,12 @@
 import {observable, action, computed} from "mobx";
 import _ from "lodash";
 
+import {datasetNamesHeaders} from "../constants/mainConstants";
 import {
-    modelTypes,
+    datasetTypes,
     columns,
     columnNames,
     datasetForm,
-    datasetNamesHeaders,
     scatter_plot_layout,
     yAxisTitle,
     model_type,
@@ -23,8 +23,8 @@ class DataStore {
     @observable selectedFile = {};
 
     @action.bound setDefaultsByDatasetType() {
-        let modelTypes = this.getFilteredDatasetTypes;
-        this.model_type = modelTypes[0].value;
+        let datasetTypes = this.getFilteredDatasetTypes;
+        this.model_type = datasetTypes[0].value;
         this.datasets = [];
     }
 
@@ -207,15 +207,15 @@ class DataStore {
     }
 
     @computed get getFilteredDatasetTypes() {
-        return modelTypes.filter(model => model.value.includes(this.getDatasetType));
+        return datasetTypes.filter(model => model.value.includes(this.getDatasetType));
     }
 
-    @computed get getModelTypesName() {
-        return modelTypes.find(item => item.value === this.model_type);
+    @computed get getModelType() {
+        return this.rootStore.mainStore.model_type;
     }
 
     @computed get getDatasetType() {
-        return this.rootStore.mainStore.dataset_type;
+        return this.rootStore.mainStore.model_type;
     }
 
     @computed get getDatasetColumns() {

--- a/frontend/src/stores/DataStore.js
+++ b/frontend/src/stores/DataStore.js
@@ -18,7 +18,7 @@ class DataStore {
         this.rootStore = rootStore;
     }
 
-    @observable model_type = "DM";
+    @observable model_type = dc.DATA_CONTINUOUS_SUMMARY;
     @observable datasets = [];
     @observable selectedDatasetIndex = null;
     @observable selectedFile = {};

--- a/frontend/src/stores/DataStore.js
+++ b/frontend/src/stores/DataStore.js
@@ -1,5 +1,6 @@
 import {observable, action, computed} from "mobx";
 import _ from "lodash";
+
 import {
     modelTypes,
     columns,
@@ -22,7 +23,7 @@ class DataStore {
     @observable selectedFile = {};
 
     @action.bound setDefaultsByDatasetType() {
-        let modelTypes = this.getFilteredModelTypes;
+        let modelTypes = this.getFilteredDatasetTypes;
         this.model_type = modelTypes[0].value;
         this.datasets = [];
     }
@@ -205,7 +206,7 @@ class DataStore {
         return this.datasets.filter(item => item.model_type.includes(this.getDatasetType));
     }
 
-    @computed get getFilteredModelTypes() {
+    @computed get getFilteredDatasetTypes() {
         return modelTypes.filter(model => model.value.includes(this.getDatasetType));
     }
 

--- a/frontend/src/stores/DataStore.js
+++ b/frontend/src/stores/DataStore.js
@@ -1,9 +1,10 @@
-import {observable, action, computed} from "mobx";
+import {observable, action, computed, toJS} from "mobx";
 import _ from "lodash";
 
 import * as mc from "../constants/mainConstants";
+import * as dc from "../constants/dataConstants";
 import {
-    datasetTypes,
+    datasetTypesByModelType,
     columns,
     columnNames,
     datasetForm,
@@ -151,11 +152,11 @@ class DataStore {
     @computed get getResponse() {
         let responses = [];
         let dataset = this.selectedDataset;
-        if (dataset.model_type === model_type.Continuous_Summarized) {
+        if (dataset.model_type === dc.DATA_CONTINUOUS_SUMMARY) {
             responses = dataset.means;
-        } else if (dataset.model_type === model_type.Continuous_Individual) {
+        } else if (dataset.model_type === dc.DATA_CONTINUOUS_INDIVIDUAL) {
             responses = dataset.responses;
-        } else if (dataset.model_type === model_type.Dichotomous) {
+        } else if (dataset.model_type === dc.DATA_DICHOTOMOUS) {
             let ns = dataset.ns;
             let incidences = dataset.incidences;
             for (var i = 0; i < ns.length; i++) {
@@ -207,7 +208,7 @@ class DataStore {
     }
 
     @computed get getFilteredDatasetTypes() {
-        return datasetTypes.filter(model => model.value.includes(this.getModelType));
+        return datasetTypesByModelType(toJS(this.getModelType));
     }
 
     @computed get getModelType() {

--- a/frontend/src/stores/DataStore.js
+++ b/frontend/src/stores/DataStore.js
@@ -1,7 +1,7 @@
 import {observable, action, computed} from "mobx";
 import _ from "lodash";
 
-import {datasetNamesHeaders} from "../constants/mainConstants";
+import * as mc from "../constants/mainConstants";
 import {
     datasetTypes,
     columns,
@@ -42,7 +42,7 @@ class DataStore {
 
     @action.bound addDataset() {
         let form = datasetForm[this.model_type];
-        if (this.getDatasetType === "DM") {
+        if (this.getModelType === mc.MODEL_DICHOTOMOUS) {
             form["degree"] = "auto-select";
             form["background"] = "Estimated";
         }
@@ -203,18 +203,14 @@ class DataStore {
     }
 
     @computed get getModelTypeDatasets() {
-        return this.datasets.filter(item => item.model_type.includes(this.getDatasetType));
+        return this.datasets.filter(item => item.model_type.includes(this.getModelType));
     }
 
     @computed get getFilteredDatasetTypes() {
-        return datasetTypes.filter(model => model.value.includes(this.getDatasetType));
+        return datasetTypes.filter(model => model.value.includes(this.getModelType));
     }
 
     @computed get getModelType() {
-        return this.rootStore.mainStore.model_type;
-    }
-
-    @computed get getDatasetType() {
         return this.rootStore.mainStore.model_type;
     }
 
@@ -224,12 +220,12 @@ class DataStore {
 
     @computed get getEnabledDatasets() {
         return this.datasets.filter(
-            item => item.enabled == true && item.model_type.includes(this.getDatasetType)
+            item => item.enabled == true && item.model_type.includes(this.getModelType)
         );
     }
 
     @computed get getDatasetNamesHeader() {
-        return datasetNamesHeaders[this.getDatasetType];
+        return mc.datasetNamesHeaders[this.getModelType];
     }
 
     @computed get checkDatasetsLength() {

--- a/frontend/src/stores/MainStore.js
+++ b/frontend/src/stores/MainStore.js
@@ -175,6 +175,7 @@ class MainStore {
 
         const inputs = data.inputs;
         if (_.isEmpty(inputs)) {
+            this.changeDatasetType(this.model_type);
             this.isUpdateComplete = true;
             return;
         }
@@ -188,6 +189,7 @@ class MainStore {
         this.analysis_name = inputs.analysis_name;
         this.analysis_description = inputs.analysis_description;
         this.model_type = inputs.dataset_type;
+        this.changeDatasetType(this.model_type);
         this.rootStore.optionsStore.setOptions(inputs.options);
         this.rootStore.dataStore.setDatasets(inputs.datasets);
         this.rootStore.modelsStore.setModels(inputs.models);

--- a/frontend/src/stores/MainStore.js
+++ b/frontend/src/stores/MainStore.js
@@ -2,8 +2,8 @@ import {saveAs} from "file-saver";
 import slugify from "slugify";
 import {observable, action, computed} from "mobx";
 import _ from "lodash";
-import {modelTypes} from "../constants/mainConstants";
 
+import * as mc from "../constants/mainConstants";
 import {simulateClick, getHeaders} from "../common";
 
 class MainStore {
@@ -16,7 +16,7 @@ class MainStore {
 
     @observable analysis_name = "";
     @observable analysis_description = "";
-    @observable dataset_type = modelTypes[0].value;
+    @observable dataset_type = mc.MODEL_CONTINUOUS;
     @observable errorMessage = "";
     @observable hasEditSettings = false;
     @observable executionOutputs = null;
@@ -235,7 +235,7 @@ class MainStore {
         return this.rootStore.dataStore.getDataLength;
     }
     @computed get getDatasetTypeName() {
-        return modelTypes.find(item => item.value == this.dataset_type);
+        return mc.modelTypes.find(item => item.value == this.dataset_type);
     }
 
     @computed get hasAtLeastOneModelSelected() {

--- a/frontend/src/stores/MainStore.js
+++ b/frontend/src/stores/MainStore.js
@@ -16,7 +16,7 @@ class MainStore {
 
     @observable analysis_name = "";
     @observable analysis_description = "";
-    @observable dataset_type = mc.MODEL_CONTINUOUS;
+    @observable model_type = mc.MODEL_CONTINUOUS;
     @observable errorMessage = "";
     @observable hasEditSettings = false;
     @observable executionOutputs = null;
@@ -32,7 +32,7 @@ class MainStore {
         this.analysis_description = value;
     }
     @action changeDatasetType(value) {
-        this.dataset_type = value;
+        this.model_type = value;
         this.rootStore.modelsStore.setDefaultsByDatasetType();
         this.rootStore.optionsStore.setDefaultsByDatasetType();
         this.rootStore.dataStore.setDefaultsByDatasetType();
@@ -56,10 +56,10 @@ class MainStore {
             editKey,
             partial: true,
             data: {
-                bmds_version: "BMDS330",
+                bmds_version: mc.VERSION_330,
                 analysis_name: this.analysis_name,
                 analysis_description: this.analysis_description,
-                dataset_type: this.dataset_type,
+                dataset_type: this.model_type,
                 models: this.getEnabledModels,
                 datasets: this.getEnabledDatasets,
                 options: this.getOptions,
@@ -187,7 +187,7 @@ class MainStore {
         // unpack general settings
         this.analysis_name = inputs.analysis_name;
         this.analysis_description = inputs.analysis_description;
-        this.dataset_type = inputs.dataset_type;
+        this.model_type = inputs.dataset_type;
         this.rootStore.optionsStore.setOptions(inputs.options);
         this.rootStore.dataStore.setDatasets(inputs.datasets);
         this.rootStore.modelsStore.setModels(inputs.models);
@@ -234,8 +234,8 @@ class MainStore {
     @computed get getDatasetLength() {
         return this.rootStore.dataStore.getDataLength;
     }
-    @computed get getDatasetTypeName() {
-        return mc.modelTypes.find(item => item.value == this.dataset_type);
+    @computed get getModelTypeName() {
+        return mc.modelTypes.find(item => item.value == this.model_type).name;
     }
 
     @computed get hasAtLeastOneModelSelected() {

--- a/frontend/src/stores/ModelsStore.js
+++ b/frontend/src/stores/ModelsStore.js
@@ -20,7 +20,7 @@ class ModelsStore {
     }
 
     @action setDefaultsByDatasetType() {
-        let modelType = this.rootStore.mainStore.dataset_type;
+        let modelType = this.rootStore.mainStore.model_type;
         this.models = _.cloneDeep(modelsList[modelType]);
         if (modelType === mc.MODEL_NESTED) {
             this.model_headers = nestedHeaders;

--- a/frontend/src/stores/ModelsStore.js
+++ b/frontend/src/stores/ModelsStore.js
@@ -1,11 +1,7 @@
 import {observable, action, computed} from "mobx";
-import {
-    modelsList,
-    modelHeaders,
-    nestedHeaders,
-    model,
-    datasetType,
-} from "../constants/modelConstants";
+
+import * as mc from "../constants/mainConstants";
+import {modelsList, modelHeaders, nestedHeaders, model} from "../constants/modelConstants";
 import _ from "lodash";
 
 class ModelsStore {
@@ -24,9 +20,9 @@ class ModelsStore {
     }
 
     @action setDefaultsByDatasetType() {
-        let dataset_type = this.rootStore.mainStore.dataset_type;
-        this.models = _.cloneDeep(modelsList[dataset_type]);
-        if (dataset_type === datasetType.Nested) {
+        let modelType = this.rootStore.mainStore.dataset_type;
+        this.models = _.cloneDeep(modelsList[modelType]);
+        if (modelType === mc.MODEL_NESTED) {
             this.model_headers = nestedHeaders;
         } else {
             this.model_headers = modelHeaders;

--- a/frontend/src/stores/OptionsStore.js
+++ b/frontend/src/stores/OptionsStore.js
@@ -39,7 +39,7 @@ class OptionsStore {
     }
 
     @computed get getDatasetType() {
-        return this.rootStore.mainStore.dataset_type;
+        return this.rootStore.mainStore.model_type;
     }
 
     @computed get canAddNewOption() {

--- a/frontend/src/stores/OptionsStore.js
+++ b/frontend/src/stores/OptionsStore.js
@@ -16,13 +16,13 @@ class OptionsStore {
     }
 
     @action.bound setDefaultsByDatasetType() {
-        const option = _.cloneDeep(constant.options[this.getDatasetType]);
+        const option = _.cloneDeep(constant.options[this.getModelType]);
         this.optionsList = [option];
-        this.headers = constant.headers[this.getDatasetType];
+        this.headers = constant.headers[this.getModelType];
     }
 
     @action.bound addOptions() {
-        const option = _.cloneDeep(constant.options[this.getDatasetType]);
+        const option = _.cloneDeep(constant.options[this.getModelType]);
         this.optionsList.push(option);
     }
 
@@ -35,10 +35,10 @@ class OptionsStore {
     }
     @action setOptions(options) {
         this.optionsList = options;
-        this.headers = constant.headers[this.getDatasetType];
+        this.headers = constant.headers[this.getModelType];
     }
 
-    @computed get getDatasetType() {
+    @computed get getModelType() {
         return this.rootStore.mainStore.model_type;
     }
 

--- a/frontend/src/stores/OutputStore.js
+++ b/frontend/src/stores/OutputStore.js
@@ -84,15 +84,6 @@ class OutputStore {
         return modelData;
     }
 
-    @computed get getLoglikelihoods() {
-        return this.selectedModel.results.loglikelihoods;
-    }
-
-    @computed get getTestofInterest() {
-        let rows = this.selectedModel.results.test_rows;
-        return rows;
-    }
-
     @computed get getPValue() {
         let percentileValue = _.range(0.01, 1, 0.01);
         let pValue = percentileValue.map(function(each_element) {

--- a/frontend/src/stores/OutputStore.js
+++ b/frontend/src/stores/OutputStore.js
@@ -1,7 +1,8 @@
 import {observable, action, computed} from "mobx";
 import _ from "lodash";
+
+import * as dc from "../constants/dataConstants";
 import * as constant from "../constants/outputConstants";
-import {model_type} from "../constants/dataConstants";
 
 class OutputStore {
     constructor(rootStore) {
@@ -105,9 +106,9 @@ class OutputStore {
         let dataset = this.getCurrentOutput.dataset;
         let ns = dataset.ns;
         let incidences = dataset.incidences;
-        if (dataset.model_type === model_type.Continuous_Summarized) {
+        if (dataset.model_type === dc.DATA_CONTINUOUS_SUMMARY) {
             responses = dataset.means;
-        } else if (dataset.model_type === model_type.Dichotomous) {
+        } else if (dataset.model_type === dc.DATA_DICHOTOMOUS) {
             for (var i = 0; i < ns.length; i++) {
                 var response = incidences[i] / ns[i];
                 responses.push(response);


### PR DESCRIPTION
- add continuous DR model
- split modelType and datasetType into two different constants
    - modelType are the model classes which can be executed
    - datasetTypes are the ways data can be entered for model types
    - used constants instead of strings for these constants
- pass modal display results or types instead of entire store (limit inputs)    
- remove redundant definitions of constants