### PR TITLE
Custom querysets + report cache flushing

### DIFF
--- a/bmds_server/analysis/admin.py
+++ b/bmds_server/analysis/admin.py
@@ -1,7 +1,25 @@
 from django.contrib import admin
+from django.contrib.admin import SimpleListFilter
+from django.db.models import TextChoices
 from django.utils.html import format_html
 
 from . import models
+
+
+class CustomQuerysetsFilter(SimpleListFilter):
+    title = "custom"
+    parameter_name = "custom"
+
+    class CustomQuerysetChoices(TextChoices):
+        MAYBE_HANGING = "hanging"
+
+    def lookups(self, request, model_admin):
+        return self.CustomQuerysetChoices.choices
+
+    def queryset(self, request, queryset):
+        value = self.value()
+        if value == self.CustomQuerysetChoices.MAYBE_HANGING:
+            return models.Analysis.maybe_hanging(queryset)
 
 
 @admin.register(models.Analysis)
@@ -9,6 +27,7 @@ class AnalysisAdmin(admin.ModelAdmin):
     list_display = ("__str__", "view_url", "edit_url", "created", "is_finished", "deletion_date")
     readonly_fields = ("password",)
     list_filter = (
+        CustomQuerysetsFilter,
         "started",
         "ended",
         "deletion_date",

--- a/bmds_server/analysis/api.py
+++ b/bmds_server/analysis/api.py
@@ -5,9 +5,9 @@ from rest_framework import exceptions, mixins, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 
+from ..common.task_cache import ReportStatus
 from ..common.validation import pydantic_validate
 from . import models, renderers, serializers, validators
-from .cache import DocxReportCache, ExcelReportCache
 
 
 @method_decorator(csrf_protect, name="dispatch")
@@ -127,10 +127,9 @@ class AnalysisViewset(mixins.CreateModelMixin, mixins.RetrieveModelMixin, viewse
         Return Excel export of outputs for selected analysis
         """
         instance = self.get_object()
-        cache = ExcelReportCache(analysis=instance)
-        response = cache.request_content()
+        response = instance.get_excel_from_cache()
 
-        if response.status is cache.status.COMPLETE:
+        if response.status is ReportStatus.COMPLETE:
             data = renderers.BinaryFile(data=response.content, filename=instance.slug)
             return Response(data)
 
@@ -142,10 +141,9 @@ class AnalysisViewset(mixins.CreateModelMixin, mixins.RetrieveModelMixin, viewse
         Return Word report for the selected analysis
         """
         instance = self.get_object()
-        cache = DocxReportCache(analysis=instance)
-        response = cache.request_content()
+        response = instance.get_docx_from_cache()
 
-        if response.status is cache.status.COMPLETE:
+        if response.status is ReportStatus.COMPLETE:
             data = renderers.BinaryFile(data=response.content, filename=instance.slug)
             return Response(data)
 

--- a/bmds_server/analysis/migrations/0001_initial.py
+++ b/bmds_server/analysis/migrations/0001_initial.py
@@ -59,7 +59,7 @@ class Migration(migrations.Migration):
             ],
             options={
                 "get_latest_by": ("created",),
-                "ordering": ("created",),
+                "ordering": ("-created",),
                 "verbose_name_plural": "Analyses",
             },
         ),

--- a/bmds_server/analysis/models.py
+++ b/bmds_server/analysis/models.py
@@ -20,6 +20,7 @@ from django.utils.text import slugify
 from django.utils.timezone import now
 
 from . import executor, tasks, utils, validators
+from .cache import DocxReportCache, ExcelReportCache
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +50,11 @@ class Analysis(models.Model):
 
     def __str__(self):
         return str(self.inputs.get("analysis_name", self.id))
+
+    def save(self, *args, **kwargs):
+        super().save(*args, **kwargs)
+        DocxReportCache(analysis=self).delete()
+        ExcelReportCache(analysis=self).delete()
 
     @property
     def slug(self) -> str:
@@ -128,6 +134,12 @@ class Analysis(models.Model):
         if not self.is_finished or self.has_errors:
             raise ValueError("Session cannot be returned")
         return [executor.AnalysisSession.deserialize(output) for output in self.outputs["outputs"]]
+
+    def get_excel_from_cache(self):
+        return ExcelReportCache(analysis=self).request_content()
+
+    def get_docx_from_cache(self):
+        return DocxReportCache(analysis=self).request_content()
 
     def to_batch(self) -> BmdsSessionBatch:
         # convert List[executor.AnalysisSession] to List[bmds.BmdsSession]

--- a/bmds_server/common/task_cache.py
+++ b/bmds_server/common/task_cache.py
@@ -34,6 +34,9 @@ class ReportCache:
     def cache_key(self):
         return f"{self.cache_prefix}-{self.analysis.id}"
 
+    def delete(self):
+        self.cache.delete(self.cache_key)
+
     def invoke_celery_task(self) -> None:
         """
         Invoke celery task to invoke which does the work in the create method.


### PR DESCRIPTION
- Add a new option on the admin to view querysets which are likely hung to investigate (started but not finished; been over an hour)
- 
<img width="933" alt="Screen Shot 2021-06-22 at 5 11 58 PM" src="https://user-images.githubusercontent.com/999952/123000021-ff720500-d37c-11eb-855a-1658b4f1a429.png">

- Fixed issue where if an analysis is saved the Excel/Docx cache was not cleared
