### PR TITLE
Stability updates

### DIFF
--- a/bmds_server/analysis/models.py
+++ b/bmds_server/analysis/models.py
@@ -14,7 +14,7 @@ from bmds.reporting.styling import Report
 from django.conf import settings
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
-from django.db import models, DataError
+from django.db import DataError, models
 from django.urls import reverse
 from django.utils.text import slugify
 from django.utils.timezone import now

--- a/bmds_server/analysis/models.py
+++ b/bmds_server/analysis/models.py
@@ -14,7 +14,7 @@ from bmds.reporting.styling import Report
 from django.conf import settings
 from django.core.cache import cache
 from django.core.exceptions import ValidationError
-from django.db import models
+from django.db import models, DataError
 from django.urls import reverse
 from django.utils.text import slugify
 from django.utils.timezone import now
@@ -52,9 +52,15 @@ class Analysis(models.Model):
         return str(self.inputs.get("analysis_name", self.id))
 
     def save(self, *args, **kwargs):
-        super().save(*args, **kwargs)
-        DocxReportCache(analysis=self).delete()
-        ExcelReportCache(analysis=self).delete()
+        try:
+            super().save(*args, **kwargs)
+        except DataError:
+            self.reset_execution()
+            self.errors = ["An error occurred saving content. Please contact the developers."]
+            super().save(*args, **kwargs)
+        finally:
+            DocxReportCache(analysis=self).delete()
+            ExcelReportCache(analysis=self).delete()
 
     @property
     def slug(self) -> str:

--- a/bmds_server/analysis/transforms.py
+++ b/bmds_server/analysis/transforms.py
@@ -5,7 +5,7 @@ import bmds
 from bmds.bmds3.sessions import get_model
 from bmds.bmds3.types.continuous import ContinuousModelSettings
 from bmds.bmds3.types.dichotomous import DichotomousModelSettings
-from bmds.bmds3.types.priors import PriorClass, get_continuous_prior, get_dichotomous_prior
+from bmds.bmds3.types.priors import PriorClass
 from bmds.constants import Dtype
 
 from .validators.datasets import AdverseDirection
@@ -38,7 +38,6 @@ def build_model_settings(
     options: Dict,
     dataset_options: Dict,
 ) -> Union[DichotomousModelSettings, ContinuousModelSettings]:
-    model = get_model(bmds_version, dataset_type, model_name)
     prior_class = bmd3_prior_map[prior_class]
     if dataset_type in bmds.constants.DICHOTOMOUS_DTYPES:
         return DichotomousModelSettings(
@@ -46,7 +45,7 @@ def build_model_settings(
             alpha=1.0 - options["confidence_level"],
             bmr_type=options["bmr_type"],
             degree=dataset_options["degree"],
-            priors=get_dichotomous_prior(model.bmd_model_class, prior_class),
+            priors=prior_class,
         )
     elif dataset_type in bmds.constants.CONTINUOUS_DTYPES:
         return ContinuousModelSettings(
@@ -57,7 +56,7 @@ def build_model_settings(
             disttype=options["dist_type"],
             degree=dataset_options["degree"],
             is_increasing=is_increasing_map[dataset_options["adverse_direction"]],
-            priors=get_continuous_prior(model.bmd_model_class, prior_class),
+            priors=prior_class,
         )
     else:
         raise ValueError(f"Unknown dataset_type: {dataset_type}")

--- a/bmds_server/analysis/transforms.py
+++ b/bmds_server/analysis/transforms.py
@@ -2,7 +2,6 @@ from enum import Enum
 from typing import Dict, List, Union
 
 import bmds
-from bmds.bmds3.sessions import get_model
 from bmds.bmds3.types.continuous import ContinuousModelSettings
 from bmds.bmds3.types.dichotomous import DichotomousModelSettings
 from bmds.bmds3.types.priors import PriorClass

--- a/bmds_server/analysis/transforms.py
+++ b/bmds_server/analysis/transforms.py
@@ -78,6 +78,7 @@ def build_dataset(dataset_type: str, dataset: Dict[str, List[float]]) -> bmds.da
 def remap_exponential(models: List[str]) -> List[str]:
     # recursively expand user-specified "exponential" model into M3 and M5
     if bmds.constants.M_Exponential in models:
+        models = models.copy()  # return a copy so inputs are unchanged
         pos = models.index(bmds.constants.M_Exponential)
         models[pos : pos + 1] = (bmds.constants.M_ExponentialM3, bmds.constants.M_ExponentialM5)
     return models

--- a/frontend/src/components/IndividualModel/CDFTable.js
+++ b/frontend/src/components/IndividualModel/CDFTable.js
@@ -21,14 +21,22 @@ class CDFTable extends Component {
                     </tr>
                 </thead>
                 <tbody>
-                    {_.range(bmd_dist[0].length).map(i => {
-                        return (
-                            <tr key={i}>
-                                <td>{bmd_dist[1][i]}</td>
-                                <td>{ff(bmd_dist[0][i])}</td>
-                            </tr>
-                        );
-                    })}
+                    {bmd_dist[0].length == 0 ? (
+                        <tr>
+                            <td colSpan={2}>
+                                <i>No data available.</i>
+                            </td>
+                        </tr>
+                    ) : (
+                        _.range(bmd_dist[0].length).map(i => {
+                            return (
+                                <tr key={i}>
+                                    <td>{ff(bmd_dist[1][i])}</td>
+                                    <td>{ff(bmd_dist[0][i])}</td>
+                                </tr>
+                            );
+                        })
+                    )}
                 </tbody>
             </table>
         );

--- a/frontend/src/components/Main/OptionsForm/OptionsFormList.js
+++ b/frontend/src/components/Main/OptionsForm/OptionsFormList.js
@@ -16,7 +16,7 @@ class OptionsFormList extends Component {
             modelType = optionsStore.getModelType,
             optionsList = toJS(optionsStore.optionsList),
             distTypeHelpText =
-                "If lognormal is selected, only the Exponential and Hill models can be executed";
+                "If lognormal is selected, only the Exponential and Hill models can be executed. Other models will be removed during the execution process and will not be shown in the outputs.";
         return (
             <div>
                 <div className="panel panel-default">

--- a/frontend/src/components/Output/FrequentistResultTable.js
+++ b/frontend/src/components/Output/FrequentistResultTable.js
@@ -36,7 +36,7 @@ const getModelBinLabel = function(output, index) {
     getFootnotes = function(recommendedModelIndex, selected) {
         const icons = "*†‡§",
             fns = [];
-        if (recommendedModelIndex) {
+        if (_.isNumber(recommendedModelIndex)) {
             fns.push({
                 index: recommendedModelIndex,
                 icon: icons[fns.length],
@@ -44,7 +44,7 @@ const getModelBinLabel = function(output, index) {
                 class: "table-info",
             });
         }
-        if (selected.model_index) {
+        if (_.isNumber(selected.model_index)) {
             fns.push({
                 index: selected.model_index,
                 icon: icons[fns.length],

--- a/frontend/src/components/Output/Output.js
+++ b/frontend/src/components/Output/Output.js
@@ -17,20 +17,17 @@ import SelectInput from "../common/SelectInput";
 class Output extends Component {
     render() {
         const {outputStore} = this.props,
-            {canEdit, selectedOutput, selectedFrequentist, selectedBayesian} = outputStore;
+            {
+                canEdit,
+                selectedOutputErrorMessage,
+                selectedFrequentist,
+                selectedBayesian,
+            } = outputStore;
 
-        if (selectedOutput === null) {
+        if (selectedOutputErrorMessage) {
             return (
                 <div className="container-fluid">
-                    <p>No results available.</p>
-                </div>
-            );
-        }
-
-        if ("error" in selectedOutput) {
-            return (
-                <div className="container-fluid">
-                    <pre>{selectedOutput.error}</pre>
+                    <pre>{selectedOutputErrorMessage}</pre>
                 </div>
             );
         }

--- a/frontend/src/stores/MainStore.js
+++ b/frontend/src/stores/MainStore.js
@@ -203,7 +203,7 @@ class MainStore {
     }
     @action.bound
     updateModelStateFromApi(data) {
-        if (data.errors.length > 2) {
+        if (data.errors.length > 0) {
             this.errorMessage = data.errors;
             this.isUpdateComplete = true;
         }

--- a/frontend/src/stores/OutputStore.js
+++ b/frontend/src/stores/OutputStore.js
@@ -206,8 +206,8 @@ class OutputStore {
         );
     }
     @computed get drBayesianPlotData() {
-        const bayesian_plot_data = [getDrDatasetPlotData(this.selectedDataset)];
-        const output = this.selectedOutput;
+        const bayesian_plot_data = [getDrDatasetPlotData(this.selectedDataset)],
+            output = this.selectedOutput;
         output.bayesian.models.map((model, index) => {
             let bayesian_model = {
                 x: model.results.plotting.dr_x,
@@ -228,12 +228,11 @@ class OutputStore {
     }
     @computed get drBayesianPlotLayout() {
         // the bayesian plot shown on the output page and modal
-        let layout = _.cloneDeep(this.drFrequentistPlotLayout);
-        const output = this.selectedOutput;
-        layout.annotations = getBayesianBMDLine(
-            output.bayesian.model_average,
-            bmaColor
-        ).annotations;
+        let layout = _.cloneDeep(this.drFrequentistPlotLayout),
+            output = this.selectedOutput;
+        layout.annotations = output.bayesian.model_average
+            ? getBayesianBMDLine(output.bayesian.model_average, bmaColor).annotations
+            : [];
         return layout;
     }
 

--- a/frontend/src/stores/OutputStore.js
+++ b/frontend/src/stores/OutputStore.js
@@ -36,6 +36,22 @@ class OutputStore {
         this.selectedOutputIndex = output_id;
     }
 
+    @computed get globalErrorMessage() {
+        return this.rootStore.mainStore.errorMessage;
+    }
+
+    @computed get selectedOutputErrorMessage() {
+        if (this.globalErrorMessage) {
+            return this.globalErrorMessage;
+        } else if (this.selectedOutput === null) {
+            return "No results available.";
+        } else if ("error" in this.selectedOutput) {
+            return this.selectedOutput.error;
+        } else {
+            return null;
+        }
+    }
+
     @computed get canEdit() {
         return this.rootStore.mainStore.canEdit;
     }


### PR DESCRIPTION
Updates based on testing continuous model using the new bmds API and test suite.  Upon some very basic testing, the UI appears to now be ready for use with both continuous and dichotomous models.

Changes:
- use updated `bmds` api to pass prior class enum instead of full model prior object
- catch cases where results could not be saved to database (eg., NaN, inf)

Bugfixes:
- handle no CDF data available
- handle case where no model is selected in modal plot
- update help text for dist type lognormal
- fix falsy case where if selected model is index 0, its treated as false
- fix bug where exponential case is mutated