### PR TITLE
test coverage and code cleanup

### DIFF
--- a/bmds_server/analysis/transforms.py
+++ b/bmds_server/analysis/transforms.py
@@ -17,7 +17,6 @@ class PriorEnum(str, Enum):
     bayesian = "bayesian"
 
 
-# TODO - remove these maps; use contants from bmds
 bmd3_prior_map = {
     PriorEnum.frequentist_restricted: PriorClass.frequentist_restricted,
     PriorEnum.frequentist_unrestricted: PriorClass.frequentist_unrestricted,
@@ -83,7 +82,7 @@ def remap_bayesian_exponential(models: List[Dict]) -> List[Dict]:
     for i, model in enumerate(models):
         if model["model"] == bmds.constants.M_Exponential:
             models = deepcopy(models)
-            weight = model["prior_weight"] / 2  # TODO - revisit when CMA is live - is this right?
+            weight = model["prior_weight"] / 2  # TODO - revisit when CMA is live
             models[i : i + 1] = (
                 dict(model=bmds.constants.M_ExponentialM3, prior_weight=weight),
                 dict(model=bmds.constants.M_ExponentialM5, prior_weight=weight),

--- a/bmds_server/main/celery.py
+++ b/bmds_server/main/celery.py
@@ -1,5 +1,4 @@
 import os
-from datetime import timedelta
 
 from celery import Celery
 
@@ -18,10 +17,12 @@ app.autodiscover_tasks()
 app.conf.beat_schedule = {
     "worker-healthcheck": {
         "task": "bmds_server.common.tasks.worker_healthcheck_push",
-        "schedule": timedelta(minutes=5),
+        "schedule": 5 * 60,  # every 5 min
+        "options": {"expires": 5 * 60},
     },
     "ten-minutes-delete-old-analyses": {
         "task": "bmds_server.analysis.tasks.delete_old_analyses",
-        "schedule": timedelta(minutes=10),
+        "schedule": 60 * 60,  # every hour
+        "options": {"expires": 60 * 60},
     },
 }

--- a/bmds_server/main/celery.py
+++ b/bmds_server/main/celery.py
@@ -1,4 +1,5 @@
 import os
+from datetime import timedelta
 
 from celery import Celery
 
@@ -17,12 +18,12 @@ app.autodiscover_tasks()
 app.conf.beat_schedule = {
     "worker-healthcheck": {
         "task": "bmds_server.common.tasks.worker_healthcheck_push",
-        "schedule": 5 * 60,  # every 5 min
-        "options": {"expires": 5 * 60},
+        "schedule": timedelta(minutes=5),
+        "options": {"expires": timedelta(minutes=5).total_seconds()},
     },
     "ten-minutes-delete-old-analyses": {
         "task": "bmds_server.analysis.tasks.delete_old_analyses",
-        "schedule": 60 * 60,  # every hour
-        "options": {"expires": 60 * 60},
+        "schedule": timedelta(minutes=60),
+        "options": {"expires": timedelta(minutes=60).total_seconds()},
     },
 }

--- a/frontend/src/components/Main/AnalysisForm/AnalysisForm.js
+++ b/frontend/src/components/Main/AnalysisForm/AnalysisForm.js
@@ -37,7 +37,7 @@ class AnalysisForm extends Component {
                             }></textarea>
                     </div>
                     <SelectInput
-                        label="Model Class"
+                        label="Model Type"
                         onChange={value => mainStore.changeDatasetType(value)}
                         value={mainStore.model_type}
                         choices={modelTypes.map((item, i) => {

--- a/tests/analysis/run3.py
+++ b/tests/analysis/run3.py
@@ -1,0 +1,7 @@
+import os
+
+
+# TODO remove when dll released
+class RunBmds3:
+    should_run = os.getenv("CI") is None
+    skip_reason = "DLLs not present on CI"

--- a/tests/analysis/test_api.py
+++ b/tests/analysis/test_api.py
@@ -3,6 +3,7 @@ import json
 import pytest
 from bmds.bmds3.recommender import RecommenderSettings
 from rest_framework.test import APIClient
+from run3 import RunBmds3
 
 from bmds_server.analysis.models import Analysis
 
@@ -135,6 +136,7 @@ class TestPatchInputs:
         assert response.json()["inputs"] == payload["data"]
 
 
+@pytest.mark.skipif(not RunBmds3.should_run, reason=RunBmds3.skip_reason)
 @pytest.mark.django_db
 class TestExecute:
     def test_execute(self, bmds3_complete_dichotomous):
@@ -177,6 +179,7 @@ class TestExecute:
         assert response.data["outputs"] == {}
 
 
+@pytest.mark.skipif(not RunBmds3.should_run, reason=RunBmds3.skip_reason)
 @pytest.mark.django_db
 class TestModelSelection:
     def test_model_selection(self, bmds3_complete_dichotomous):

--- a/tests/analysis/test_api.py
+++ b/tests/analysis/test_api.py
@@ -155,7 +155,7 @@ class TestExecute:
         bmd = response.data["outputs"]["outputs"][0]["frequentist"]["models"][0]["results"]["bmd"]
         assert response.data["is_finished"] is True
         assert response.data["has_errors"] is False
-        assert bmd == pytest.approsx(164.3, rel=0.05)
+        assert bmd == pytest.approx(164.3, rel=0.05)
 
     def test_reset_execute(self, bmds3_complete_dichotomous):
         client = APIClient()

--- a/tests/analysis/test_models.py
+++ b/tests/analysis/test_models.py
@@ -1,18 +1,13 @@
-import os
-import platform
-
 import pytest
+from run3 import RunBmds3
 
 from bmds_server.analysis.models import Analysis
 from bmds_server.analysis.reporting.docx import build_docx
 from bmds_server.analysis.reporting.excel import build_df
 
-# TODO remove this restriction
-should_run = platform.system() != "Windows" and os.getenv("CI") is None
-
 
 @pytest.mark.django_db()
-@pytest.mark.skipif(not should_run, reason="dlls only exist for Mac")
+@pytest.mark.skipif(not RunBmds3.should_run, reason=RunBmds3.skip_reason)
 class TestBmds3Execution:
     def test_c(self, bmds3_complete_continuous):
         analysis = Analysis.objects.create(inputs=bmds3_complete_continuous)

--- a/tests/integration/test_integrations.py
+++ b/tests/integration/test_integrations.py
@@ -1,5 +1,4 @@
 import os
-import platform
 
 import pytest
 from django.contrib.staticfiles.testing import StaticLiveServerTestCase
@@ -7,11 +6,16 @@ from django.test import TestCase
 
 from .tests import continuous, dichotomous
 
+
+# TODO remove when dll released
+class RunBmds3:
+    should_run = os.getenv("CI") is None
+    skip_reason = "DLLs not present on CI"
+
+
 SKIP_INTEGRATION = os.environ.get("BMDS_INTEGRATION_TESTS") is None
 BROWSER = os.environ.get("BROWSER", "firefox")  # default to firefox; seems more stable
-
-# TODO remove this restriction
-can_execute = platform.system() == "Darwin" and os.getenv("CI") is None
+CAN_EXECUTE = RunBmds3.should_run
 
 
 @pytest.mark.skipif(SKIP_INTEGRATION, reason="integration test")
@@ -28,14 +32,14 @@ class TestIntegration(StaticLiveServerTestCase, TestCase):
     port = int(os.environ.get("LIVESERVER_PORT", 0))
 
     def test_dichotomous(self):
-        dichotomous.test_dichotomous(self.driver, self.live_server_url, can_execute=can_execute)
+        dichotomous.test_dichotomous(self.driver, self.live_server_url, can_execute=CAN_EXECUTE)
 
     def test_continuous_summary(self):
         continuous.test_continuous_summary(
-            self.driver, self.live_server_url, can_execute=can_execute
+            self.driver, self.live_server_url, can_execute=CAN_EXECUTE
         )
 
     def test_continuous_individual(self):
         continuous.test_continuous_individual(
-            self.driver, self.live_server_url, can_execute=can_execute
+            self.driver, self.live_server_url, can_execute=CAN_EXECUTE
         )

--- a/tests/integration/tests/continuous.py
+++ b/tests/integration/tests/continuous.py
@@ -7,11 +7,11 @@ def test_continuous_individual(driver, root_url, can_execute: bool):
 
     # create a new analysis
     h.click("Create a new BMDS analysis")
-    h.wait_until(h.Text("Model Class").exists)
+    h.wait_until(h.Text("Model Type").exists)
     assert "/analysis/" in driver.current_url
 
     # set main settings pages
-    h.select("Model Class", "Continuous")
+    h.select("Model Type", "Continuous")
 
     # load example dataset
     h.wait_until(h.Text("Data").exists)
@@ -62,11 +62,11 @@ def test_continuous_summary(driver, root_url, can_execute: bool):
 
     # create a new analysis
     h.click("Create a new BMDS analysis")
-    h.wait_until(h.Text("Model Class").exists)
+    h.wait_until(h.Text("Model Type").exists)
     assert "/analysis/" in driver.current_url
 
     # set main settings pages
-    h.select("Model Class", "Continuous")
+    h.select("Model Type", "Continuous")
 
     # load example dataset
     h.wait_until(h.Text("Data").exists)

--- a/tests/integration/tests/dichotomous.py
+++ b/tests/integration/tests/dichotomous.py
@@ -7,11 +7,11 @@ def test_dichotomous(driver, root_url, can_execute: bool):
 
     # create a new analysis
     h.click("Create a new BMDS analysis")
-    h.wait_until(h.Text("Model Class").exists)
+    h.wait_until(h.Text("Model Type").exists)
     assert "/analysis/" in driver.current_url
 
     # set main settings pages
-    h.select("Model Class", "Dichotomous")
+    h.select("Model Type", "Dichotomous")
 
     # select a bayesian
     h.click(h.S("#bayesian-Logistic"))


### PR DESCRIPTION
Recent updates:
- Improved test coverage and fixture cleanup
- rename "Model Class" to "Model Type" for consistency with BMDS Excel
- make celery crontasks expire (per the excellent [caktus blogpost](https://www.caktusgroup.com/blog/2021/08/11/using-celery-scheduling-tasks/))

In addition, we investigated dropping the `bmd3_prior_map` and `is_increasing_map` constants from the bmds setting library. We decided to keep these options in place, since they constants are well defined and easily json serializable. 