### PR TITLE
add lollipop summary plot

### DIFF
--- a/bmds_server/main/settings/base.py
+++ b/bmds_server/main/settings/base.py
@@ -187,7 +187,7 @@ REST_FRAMEWORK = {
         "rest_framework.throttling.AnonRateThrottle",
         "rest_framework.throttling.UserRateThrottle",
     ),
-    "DEFAULT_THROTTLE_RATES": {"anon": "10/minute", "user": "120/minute"},
+    "DEFAULT_THROTTLE_RATES": {"anon": "20/minute", "user": "120/minute"},
     "DEFAULT_AUTHENTICATION_CLASSES": (
         "rest_framework.authentication.TokenAuthentication",
         "bmds_server.common.auth.SessionCsrfAuthentication",

--- a/frontend/src/components/Output/Output.js
+++ b/frontend/src/components/Output/Output.js
@@ -26,7 +26,8 @@ class Output extends Component {
                 selectedFrequentist,
                 selectedBayesian,
             } = outputStore,
-            modelType = outputStore.getModelType;
+            modelType = outputStore.getModelType,
+            isFuture = outputStore.rootStore.mainStore.isFuture;
 
         if (selectedOutputErrorMessage) {
             return (
@@ -89,24 +90,26 @@ class Output extends Component {
                     </div>
                 ) : null}
 
-                <div className="row">
-                    {selectedFrequentist ? (
-                        <div className="col col-lg-6">
-                            <DoseResponsePlot
-                                layout={outputStore.drFrequentistLollipopPlotLayout}
-                                data={outputStore.drFrequentistLollipopPlotDataset}
-                            />
-                        </div>
-                    ) : null}
-                    {selectedBayesian ? (
-                        <div className="col col-lg-6">
-                            <DoseResponsePlot
-                                layout={outputStore.drBayesianLollipopPlotLayout}
-                                data={outputStore.drBayesianLollipopPlotDataset}
-                            />
-                        </div>
-                    ) : null}
-                </div>
+                {isFuture ? (
+                    <div className="row">
+                        {selectedFrequentist ? (
+                            <div className="col col-lg-6">
+                                <DoseResponsePlot
+                                    layout={outputStore.drFrequentistLollipopPlotLayout}
+                                    data={outputStore.drFrequentistLollipopPlotDataset}
+                                />
+                            </div>
+                        ) : null}
+                        {selectedBayesian ? (
+                            <div className="col col-lg-6">
+                                <DoseResponsePlot
+                                    layout={outputStore.drBayesianLollipopPlotLayout}
+                                    data={outputStore.drBayesianLollipopPlotDataset}
+                                />
+                            </div>
+                        ) : null}
+                    </div>
+                ) : null}
 
                 <div>{outputStore.showModelModal ? <ModelDetailModal /> : null}</div>
             </div>

--- a/frontend/src/components/Output/Output.js
+++ b/frontend/src/components/Output/Output.js
@@ -1,5 +1,5 @@
-import React, { Component } from "react";
-import { inject, observer } from "mobx-react";
+import React, {Component} from "react";
+import {inject, observer} from "mobx-react";
 import PropTypes from "prop-types";
 
 import ModelDetailModal from "../IndividualModel/ModelDetailModal";
@@ -16,7 +16,7 @@ import SelectInput from "../common/SelectInput";
 @observer
 class Output extends Component {
     render() {
-        const { outputStore } = this.props,
+        const {outputStore} = this.props,
             {
                 canEdit,
                 selectedOutputErrorMessage,
@@ -41,7 +41,7 @@ class Output extends Component {
                             onChange={value => outputStore.setSelectedOutputIndex(parseInt(value))}
                             value={outputStore.selectedOutputIndex}
                             choices={outputStore.outputs.map((output, idx) => {
-                                return { value: idx, text: outputStore.getOutputName(idx) };
+                                return {value: idx, text: outputStore.getOutputName(idx)};
                             })}
                         />
                     </div>

--- a/frontend/src/components/Output/Output.js
+++ b/frontend/src/components/Output/Output.js
@@ -1,5 +1,5 @@
-import React, {Component} from "react";
-import {inject, observer} from "mobx-react";
+import React, { Component } from "react";
+import { inject, observer } from "mobx-react";
 import PropTypes from "prop-types";
 
 import ModelDetailModal from "../IndividualModel/ModelDetailModal";
@@ -16,7 +16,7 @@ import SelectInput from "../common/SelectInput";
 @observer
 class Output extends Component {
     render() {
-        const {outputStore} = this.props,
+        const { outputStore } = this.props,
             {
                 canEdit,
                 selectedOutputErrorMessage,
@@ -41,7 +41,7 @@ class Output extends Component {
                             onChange={value => outputStore.setSelectedOutputIndex(parseInt(value))}
                             value={outputStore.selectedOutputIndex}
                             choices={outputStore.outputs.map((output, idx) => {
-                                return {value: idx, text: outputStore.getOutputName(idx)};
+                                return { value: idx, text: outputStore.getOutputName(idx) };
                             })}
                         />
                     </div>
@@ -80,6 +80,26 @@ class Output extends Component {
                         </div>
                     </div>
                 ) : null}
+
+                <div className="row">
+                    {selectedFrequentist ? (
+                        <div className="col col-lg-6">
+                            <DoseResponsePlot
+                                layout={outputStore.drFrequentistLollipopPlotLayout}
+                                data={outputStore.drFrequentistLollipopPlotDataset}
+                            />
+                        </div>
+                    ) : null}
+                    {selectedBayesian ? (
+                        <div className="col col-lg-6">
+                            <DoseResponsePlot
+                                layout={outputStore.drBayesianLollipopPlotLayout}
+                                data={outputStore.drBayesianLollipopPlotDataset}
+                            />
+                        </div>
+                    ) : null}
+                </div>
+
                 <div>{outputStore.showModelModal ? <ModelDetailModal /> : null}</div>
             </div>
         );

--- a/frontend/src/constants/plotting.js
+++ b/frontend/src/constants/plotting.js
@@ -253,7 +253,7 @@ export const getDoseLabel = function(dataset) {
             title: {
                 text: title,
             },
-            margin: {l: 100, r: 5, t: 30, b: 40},
+            margin: {l: 100, r: 5, t: 35, b: 65},
             showlegend: false,
             xaxis: {
                 showline: true,

--- a/frontend/src/constants/plotting.js
+++ b/frontend/src/constants/plotting.js
@@ -42,19 +42,22 @@ const doseResponseLayout = {
         }
     };
 
-export const getDrLayout = function(dataset, selected, modal, hover) {
-        let layout = _.cloneDeep(doseResponseLayout),
-            xlabel = dataset.metadata.dose_name,
-            ylabel = dataset.metadata.response_name;
-
+export const getDoseLabel = function(dataset) {
+        let label = dataset.metadata.dose_name;
         if (dataset.metadata.dose_units) {
-            xlabel = `${xlabel} (${dataset.metadata.dose_units})`;
+            label = `${label} (${dataset.metadata.dose_units})`;
         }
-
+        return label;
+    },
+    getResponseLabel = function(dataset) {
+        let label = dataset.metadata.response_name;
         if (dataset.metadata.response_units) {
-            ylabel = `${ylabel} (${dataset.metadata.response_units})`;
+            label = `${label} (${dataset.metadata.response_units})`;
         }
-
+        return label;
+    },
+    getDrLayout = function(dataset, selected, modal, hover) {
+        let layout = _.cloneDeep(doseResponseLayout);
         const annotations = [];
         if (selected && selected.annotations) {
             annotations.push(selected.annotations);
@@ -68,8 +71,8 @@ export const getDrLayout = function(dataset, selected, modal, hover) {
         layout.annotations = _.flatten(annotations);
 
         layout.title.text = dataset.metadata.name;
-        layout.xaxis.title.text = xlabel;
-        layout.yaxis.title.text = ylabel;
+        layout.xaxis.title.text = getDoseLabel(dataset);
+        layout.yaxis.title.text = getResponseLabel(dataset);
         const xmin = _.min(dataset.doses) || 0,
             xmax = _.max(dataset.doses) || 0,
             response = getResponse(dataset),
@@ -105,17 +108,11 @@ export const getDrLayout = function(dataset, selected, modal, hover) {
         return layout;
     },
     getCdfLayout = function(dataset) {
-        let layout = _.cloneDeep(doseResponseLayout),
-            xlabel = dataset.metadata.dose_name;
-
-        if (dataset.metadata.dose_units) {
-            xlabel = `${xlabel} (${dataset.metadata.dose_units})`;
-        }
+        let layout = _.cloneDeep(doseResponseLayout);
         layout.title.text = "BMD Cumulative distribution function";
-        layout.xaxis.title.text = xlabel;
+        layout.xaxis.title.text = getDoseLabel(dataset);
         layout.yaxis.title.text = "Percentile";
         layout.yaxis.range = [0, 1];
-
         return layout;
     },
     getDrDatasetPlotData = function(dataset) {
@@ -251,15 +248,22 @@ export const getDrLayout = function(dataset, selected, modal, hover) {
             name: modelName,
         };
     },
-    getLollipopPlotLayout = {
-        title: "",
-        showlegend: false,
-        xaxis: {
-            showline: true,
-        },
-        yaxis: {
-            showline: true,
-        },
+    getLollipopPlotLayout = function(title, dataset) {
+        const layout = {
+            title: {
+                text: title,
+            },
+            margin: {l: 100, r: 5, t: 30, b: 40},
+            showlegend: false,
+            xaxis: {
+                showline: true,
+                title: getDoseLabel(dataset),
+            },
+            yaxis: {
+                showline: true,
+            },
+        };
+        return layout;
     },
     getConfig = function() {
         return {

--- a/frontend/src/constants/plotting.js
+++ b/frontend/src/constants/plotting.js
@@ -1,26 +1,26 @@
 import _ from "lodash";
-import { Dtype } from "./dataConstants";
-import { continuousErrorBars, dichotomousErrorBars } from "../utils/errorBars";
+import {Dtype} from "./dataConstants";
+import {continuousErrorBars, dichotomousErrorBars} from "../utils/errorBars";
 
 const doseResponseLayout = {
-    autosize: true,
-    legend: { yanchor: "top", y: 0.99, xanchor: "left", x: 0.01 },
-    margin: { l: 50, r: 5, t: 50, b: 50 },
-    showlegend: true,
-    title: {
-        text: "ADD",
-    },
-    xaxis: {
+        autosize: true,
+        legend: {yanchor: "top", y: 0.99, xanchor: "left", x: 0.01},
+        margin: {l: 50, r: 5, t: 50, b: 50},
+        showlegend: true,
         title: {
             text: "ADD",
         },
-    },
-    yaxis: {
-        title: {
-            text: "ADD",
+        xaxis: {
+            title: {
+                text: "ADD",
+            },
+        },
+        yaxis: {
+            title: {
+                text: "ADD",
+            },
         },
     },
-},
     getResponse = dataset => {
         let incidences, ns;
 
@@ -42,69 +42,69 @@ const doseResponseLayout = {
         }
     };
 
-export const getDrLayout = function (dataset, selected, modal, hover) {
-    let layout = _.cloneDeep(doseResponseLayout),
-        xlabel = dataset.metadata.dose_name,
-        ylabel = dataset.metadata.response_name;
+export const getDrLayout = function(dataset, selected, modal, hover) {
+        let layout = _.cloneDeep(doseResponseLayout),
+            xlabel = dataset.metadata.dose_name,
+            ylabel = dataset.metadata.response_name;
 
-    if (dataset.metadata.dose_units) {
-        xlabel = `${xlabel} (${dataset.metadata.dose_units})`;
-    }
+        if (dataset.metadata.dose_units) {
+            xlabel = `${xlabel} (${dataset.metadata.dose_units})`;
+        }
 
-    if (dataset.metadata.response_units) {
-        ylabel = `${ylabel} (${dataset.metadata.response_units})`;
-    }
+        if (dataset.metadata.response_units) {
+            ylabel = `${ylabel} (${dataset.metadata.response_units})`;
+        }
 
-    const annotations = [];
-    if (selected && selected.annotations) {
-        annotations.push(selected.annotations);
-    }
-    if (modal && modal.annotations) {
-        annotations.push(modal.annotations);
-    }
-    if (hover && hover.annotations) {
-        annotations.push(hover.annotations);
-    }
-    layout.annotations = _.flatten(annotations);
+        const annotations = [];
+        if (selected && selected.annotations) {
+            annotations.push(selected.annotations);
+        }
+        if (modal && modal.annotations) {
+            annotations.push(modal.annotations);
+        }
+        if (hover && hover.annotations) {
+            annotations.push(hover.annotations);
+        }
+        layout.annotations = _.flatten(annotations);
 
-    layout.title.text = dataset.metadata.name;
-    layout.xaxis.title.text = xlabel;
-    layout.yaxis.title.text = ylabel;
-    const xmin = _.min(dataset.doses) || 0,
-        xmax = _.max(dataset.doses) || 0,
-        response = getResponse(dataset),
-        ymin =
-            dataset.dtype == Dtype.CONTINUOUS
-                ? _.min(response) - _.max(continuousErrorBars(dataset).uppers)
-                : _.min(response) || 0,
-        ymax =
-            dataset.dtype == Dtype.CONTINUOUS
-                ? _.max(response) + _.max(continuousErrorBars(dataset).uppers)
-                : _.max(response) || 0,
-        xbuff = Math.abs(xmax - xmin) * 0.05,
-        ybuff = Math.abs(ymax - ymin) * 0.05;
+        layout.title.text = dataset.metadata.name;
+        layout.xaxis.title.text = xlabel;
+        layout.yaxis.title.text = ylabel;
+        const xmin = _.min(dataset.doses) || 0,
+            xmax = _.max(dataset.doses) || 0,
+            response = getResponse(dataset),
+            ymin =
+                dataset.dtype == Dtype.CONTINUOUS
+                    ? _.min(response) - _.max(continuousErrorBars(dataset).uppers)
+                    : _.min(response) || 0,
+            ymax =
+                dataset.dtype == Dtype.CONTINUOUS
+                    ? _.max(response) + _.max(continuousErrorBars(dataset).uppers)
+                    : _.max(response) || 0,
+            xbuff = Math.abs(xmax - xmin) * 0.05,
+            ybuff = Math.abs(ymax - ymin) * 0.05;
 
-    layout.xaxis.range = [xmin == 0 ? -xbuff : xmin - xbuff, xmax == 0 ? xbuff : xmax + xbuff];
-    layout.yaxis.range =
-        dataset.dtype == Dtype.DICHOTOMOUS || dataset.dtype == Dtype.NESTED_DICHOTOMOUS
-            ? [-0.05, 1.05]
-            : [ymin == 0 ? -ybuff : ymin - ybuff, ymax == 0 ? ybuff : ymax + ybuff];
+        layout.xaxis.range = [xmin == 0 ? -xbuff : xmin - xbuff, xmax == 0 ? xbuff : xmax + xbuff];
+        layout.yaxis.range =
+            dataset.dtype == Dtype.DICHOTOMOUS || dataset.dtype == Dtype.NESTED_DICHOTOMOUS
+                ? [-0.05, 1.05]
+                : [ymin == 0 ? -ybuff : ymin - ybuff, ymax == 0 ? ybuff : ymax + ybuff];
 
-    // determine whether to position legend to the left or right; auto doesn't work
-    const maxResponseIndex = response.indexOf(_.max(response)),
-        maxResponseDose = dataset.doses[maxResponseIndex],
-        doseRange = _.max(dataset.doses) - _.min(dataset.doses);
+        // determine whether to position legend to the left or right; auto doesn't work
+        const maxResponseIndex = response.indexOf(_.max(response)),
+            maxResponseDose = dataset.doses[maxResponseIndex],
+            doseRange = _.max(dataset.doses) - _.min(dataset.doses);
 
-    if (maxResponseDose < doseRange / 2) {
-        layout.legend.xanchor = "right";
-        layout.legend.x = 1;
-    } else {
-        layout.legend.xanchor = "left";
-        layout.legend.x = 0.05;
-    }
-    return layout;
-},
-    getCdfLayout = function (dataset) {
+        if (maxResponseDose < doseRange / 2) {
+            layout.legend.xanchor = "right";
+            layout.legend.x = 1;
+        } else {
+            layout.legend.xanchor = "left";
+            layout.legend.x = 0.05;
+        }
+        return layout;
+    },
+    getCdfLayout = function(dataset) {
         let layout = _.cloneDeep(doseResponseLayout),
             xlabel = dataset.metadata.dose_name;
 
@@ -118,7 +118,7 @@ export const getDrLayout = function (dataset, selected, modal, hover) {
 
         return layout;
     },
-    getDrDatasetPlotData = function (dataset) {
+    getDrDatasetPlotData = function(dataset) {
         let errorBars, hovertemplate;
         if (dataset.dtype == Dtype.CONTINUOUS) {
             errorBars = continuousErrorBars(dataset);
@@ -143,7 +143,7 @@ export const getDrLayout = function (dataset, selected, modal, hover) {
             name: "Response",
         };
     },
-    getDrBmdLine = function (model, hexColor) {
+    getDrBmdLine = function(model, hexColor) {
         const annotations = [];
         if (model.results.bmd) {
             // https://plotly.com/javascript/reference/layout/annotations/#layout-annotations
@@ -189,7 +189,7 @@ export const getDrLayout = function (dataset, selected, modal, hover) {
             annotations,
         };
     },
-    getBayesianBMDLine = function (model, hexColor) {
+    getBayesianBMDLine = function(model, hexColor) {
         const annotations = [];
         if (model.results.bmd) {
             // https://plotly.com/javascript/reference/layout/annotations/#layout-annotations
@@ -234,7 +234,7 @@ export const getDrLayout = function (dataset, selected, modal, hover) {
         };
         return bma_data;
     },
-    getLollipopDataset = function (dataArray, modelArray, modelName) {
+    getLollipopDataset = function(dataArray, modelArray, modelName) {
         return {
             x: dataArray,
             y: modelArray,
@@ -261,7 +261,7 @@ export const getDrLayout = function (dataset, selected, modal, hover) {
             showline: true,
         },
     },
-    getConfig = function () {
+    getConfig = function() {
         return {
             modeBarButtonsToRemove: [
                 "pan2d",

--- a/frontend/src/constants/plotting.js
+++ b/frontend/src/constants/plotting.js
@@ -1,26 +1,26 @@
 import _ from "lodash";
-import {Dtype} from "./dataConstants";
-import {continuousErrorBars, dichotomousErrorBars} from "../utils/errorBars";
+import { Dtype } from "./dataConstants";
+import { continuousErrorBars, dichotomousErrorBars } from "../utils/errorBars";
 
 const doseResponseLayout = {
-        autosize: true,
-        legend: {yanchor: "top", y: 0.99, xanchor: "left", x: 0.01},
-        margin: {l: 50, r: 5, t: 50, b: 50},
-        showlegend: true,
+    autosize: true,
+    legend: { yanchor: "top", y: 0.99, xanchor: "left", x: 0.01 },
+    margin: { l: 50, r: 5, t: 50, b: 50 },
+    showlegend: true,
+    title: {
+        text: "ADD",
+    },
+    xaxis: {
         title: {
             text: "ADD",
         },
-        xaxis: {
-            title: {
-                text: "ADD",
-            },
-        },
-        yaxis: {
-            title: {
-                text: "ADD",
-            },
+    },
+    yaxis: {
+        title: {
+            text: "ADD",
         },
     },
+},
     getResponse = dataset => {
         let incidences, ns;
 
@@ -42,69 +42,69 @@ const doseResponseLayout = {
         }
     };
 
-export const getDrLayout = function(dataset, selected, modal, hover) {
-        let layout = _.cloneDeep(doseResponseLayout),
-            xlabel = dataset.metadata.dose_name,
-            ylabel = dataset.metadata.response_name;
+export const getDrLayout = function (dataset, selected, modal, hover) {
+    let layout = _.cloneDeep(doseResponseLayout),
+        xlabel = dataset.metadata.dose_name,
+        ylabel = dataset.metadata.response_name;
 
-        if (dataset.metadata.dose_units) {
-            xlabel = `${xlabel} (${dataset.metadata.dose_units})`;
-        }
+    if (dataset.metadata.dose_units) {
+        xlabel = `${xlabel} (${dataset.metadata.dose_units})`;
+    }
 
-        if (dataset.metadata.response_units) {
-            ylabel = `${ylabel} (${dataset.metadata.response_units})`;
-        }
+    if (dataset.metadata.response_units) {
+        ylabel = `${ylabel} (${dataset.metadata.response_units})`;
+    }
 
-        const annotations = [];
-        if (selected && selected.annotations) {
-            annotations.push(selected.annotations);
-        }
-        if (modal && modal.annotations) {
-            annotations.push(modal.annotations);
-        }
-        if (hover && hover.annotations) {
-            annotations.push(hover.annotations);
-        }
-        layout.annotations = _.flatten(annotations);
+    const annotations = [];
+    if (selected && selected.annotations) {
+        annotations.push(selected.annotations);
+    }
+    if (modal && modal.annotations) {
+        annotations.push(modal.annotations);
+    }
+    if (hover && hover.annotations) {
+        annotations.push(hover.annotations);
+    }
+    layout.annotations = _.flatten(annotations);
 
-        layout.title.text = dataset.metadata.name;
-        layout.xaxis.title.text = xlabel;
-        layout.yaxis.title.text = ylabel;
-        const xmin = _.min(dataset.doses) || 0,
-            xmax = _.max(dataset.doses) || 0,
-            response = getResponse(dataset),
-            ymin =
-                dataset.dtype == Dtype.CONTINUOUS
-                    ? _.min(response) - _.max(continuousErrorBars(dataset).uppers)
-                    : _.min(response) || 0,
-            ymax =
-                dataset.dtype == Dtype.CONTINUOUS
-                    ? _.max(response) + _.max(continuousErrorBars(dataset).uppers)
-                    : _.max(response) || 0,
-            xbuff = Math.abs(xmax - xmin) * 0.05,
-            ybuff = Math.abs(ymax - ymin) * 0.05;
+    layout.title.text = dataset.metadata.name;
+    layout.xaxis.title.text = xlabel;
+    layout.yaxis.title.text = ylabel;
+    const xmin = _.min(dataset.doses) || 0,
+        xmax = _.max(dataset.doses) || 0,
+        response = getResponse(dataset),
+        ymin =
+            dataset.dtype == Dtype.CONTINUOUS
+                ? _.min(response) - _.max(continuousErrorBars(dataset).uppers)
+                : _.min(response) || 0,
+        ymax =
+            dataset.dtype == Dtype.CONTINUOUS
+                ? _.max(response) + _.max(continuousErrorBars(dataset).uppers)
+                : _.max(response) || 0,
+        xbuff = Math.abs(xmax - xmin) * 0.05,
+        ybuff = Math.abs(ymax - ymin) * 0.05;
 
-        layout.xaxis.range = [xmin == 0 ? -xbuff : xmin - xbuff, xmax == 0 ? xbuff : xmax + xbuff];
-        layout.yaxis.range =
-            dataset.dtype == Dtype.DICHOTOMOUS || dataset.dtype == Dtype.NESTED_DICHOTOMOUS
-                ? [-0.05, 1.05]
-                : [ymin == 0 ? -ybuff : ymin - ybuff, ymax == 0 ? ybuff : ymax + ybuff];
+    layout.xaxis.range = [xmin == 0 ? -xbuff : xmin - xbuff, xmax == 0 ? xbuff : xmax + xbuff];
+    layout.yaxis.range =
+        dataset.dtype == Dtype.DICHOTOMOUS || dataset.dtype == Dtype.NESTED_DICHOTOMOUS
+            ? [-0.05, 1.05]
+            : [ymin == 0 ? -ybuff : ymin - ybuff, ymax == 0 ? ybuff : ymax + ybuff];
 
-        // determine whether to position legend to the left or right; auto doesn't work
-        const maxResponseIndex = response.indexOf(_.max(response)),
-            maxResponseDose = dataset.doses[maxResponseIndex],
-            doseRange = _.max(dataset.doses) - _.min(dataset.doses);
+    // determine whether to position legend to the left or right; auto doesn't work
+    const maxResponseIndex = response.indexOf(_.max(response)),
+        maxResponseDose = dataset.doses[maxResponseIndex],
+        doseRange = _.max(dataset.doses) - _.min(dataset.doses);
 
-        if (maxResponseDose < doseRange / 2) {
-            layout.legend.xanchor = "right";
-            layout.legend.x = 1;
-        } else {
-            layout.legend.xanchor = "left";
-            layout.legend.x = 0.05;
-        }
-        return layout;
-    },
-    getCdfLayout = function(dataset) {
+    if (maxResponseDose < doseRange / 2) {
+        layout.legend.xanchor = "right";
+        layout.legend.x = 1;
+    } else {
+        layout.legend.xanchor = "left";
+        layout.legend.x = 0.05;
+    }
+    return layout;
+},
+    getCdfLayout = function (dataset) {
         let layout = _.cloneDeep(doseResponseLayout),
             xlabel = dataset.metadata.dose_name;
 
@@ -118,7 +118,7 @@ export const getDrLayout = function(dataset, selected, modal, hover) {
 
         return layout;
     },
-    getDrDatasetPlotData = function(dataset) {
+    getDrDatasetPlotData = function (dataset) {
         let errorBars, hovertemplate;
         if (dataset.dtype == Dtype.CONTINUOUS) {
             errorBars = continuousErrorBars(dataset);
@@ -143,7 +143,7 @@ export const getDrLayout = function(dataset, selected, modal, hover) {
             name: "Response",
         };
     },
-    getDrBmdLine = function(model, hexColor) {
+    getDrBmdLine = function (model, hexColor) {
         const annotations = [];
         if (model.results.bmd) {
             // https://plotly.com/javascript/reference/layout/annotations/#layout-annotations
@@ -189,7 +189,7 @@ export const getDrLayout = function(dataset, selected, modal, hover) {
             annotations,
         };
     },
-    getBayesianBMDLine = function(model, hexColor) {
+    getBayesianBMDLine = function (model, hexColor) {
         const annotations = [];
         if (model.results.bmd) {
             // https://plotly.com/javascript/reference/layout/annotations/#layout-annotations
@@ -234,7 +234,34 @@ export const getDrLayout = function(dataset, selected, modal, hover) {
         };
         return bma_data;
     },
-    getConfig = function() {
+    getLollipopDataset = function (dataArray, modelArray, modelName) {
+        return {
+            x: dataArray,
+            y: modelArray,
+            mode: "line",
+            type: "scatter",
+            line: {
+                width: 5,
+                color: "#696969",
+            },
+            marker: {
+                size: 10,
+                color: ["#FFFFFF", "#0000FF", "#FFFFFF"],
+            },
+            name: modelName,
+        };
+    },
+    getLollipopPlotLayout = {
+        title: "",
+        showlegend: false,
+        xaxis: {
+            showline: true,
+        },
+        yaxis: {
+            showline: true,
+        },
+    },
+    getConfig = function () {
         return {
             modeBarButtonsToRemove: [
                 "pan2d",

--- a/frontend/src/stores/OutputStore.js
+++ b/frontend/src/stores/OutputStore.js
@@ -1,8 +1,8 @@
-import { observable, action, computed, toJS } from "mobx";
+import {observable, action, computed, toJS} from "mobx";
 import _ from "lodash";
-import { getHeaders } from "../common";
+import {getHeaders} from "../common";
 
-import { modelClasses, maIndex } from "../constants/outputConstants";
+import {modelClasses, maIndex} from "../constants/outputConstants";
 import {
     getDrLayout,
     getDrDatasetPlotData,
@@ -107,7 +107,7 @@ class OutputStore {
 
     @computed get getPValue() {
         let percentileValue = _.range(0.01, 1, 0.01);
-        let pValue = percentileValue.map(function (each_element) {
+        let pValue = percentileValue.map(function(each_element) {
             return Number(each_element.toFixed(2));
         });
         return pValue;
@@ -328,7 +328,7 @@ class OutputStore {
     }
     @action.bound saveSelectedModel() {
         const output = this.selectedOutput,
-            { csrfToken, editKey } = this.rootStore.mainStore.config.editSettings,
+            {csrfToken, editKey} = this.rootStore.mainStore.config.editSettings,
             payload = toJS({
                 editKey,
                 data: {

--- a/frontend/src/stores/OutputStore.js
+++ b/frontend/src/stores/OutputStore.js
@@ -307,15 +307,11 @@ class OutputStore {
     }
 
     @computed get drFrequentistLollipopPlotLayout() {
-        let layout = _.cloneDeep(getLollipopPlotLayout);
-        layout.title = "Frequentist bmd/bmdl/bmdu Plot";
-        return layout;
+        return getLollipopPlotLayout("Frequentist bmd/bmdl/bmdu Plot", this.selectedDataset);
     }
 
     @computed get drBayesianLollipopPlotLayout() {
-        let layout = _.cloneDeep(getLollipopPlotLayout);
-        layout.title = "Bayesian bmd/bmdl/bmdu Plot ";
-        return layout;
+        return getLollipopPlotLayout("Bayesian bmd/bmdl/bmdu Plot", this.selectedDataset);
     }
     // end dose-response plotting data methods
 


### PR DESCRIPTION
lollipop plot added for frequentist and bayesian plot added; added behind the `future` flag for authenticated users.

closes #128 

<img width="935" alt="Screen Shot 2022-04-14 at 2 57 59 PM" src="https://user-images.githubusercontent.com/999952/163458254-26819cfc-338a-4bf7-aa85-ec8be5963014.png">

In the future, prior to releasing, work on better integration with the rest of the interface.