### PR TITLE
REST auth - CSRF tokens or Tokens

### DIFF
--- a/bmds_server/analysis/api.py
+++ b/bmds_server/analysis/api.py
@@ -1,6 +1,4 @@
 from django.core.exceptions import ValidationError
-from django.utils.decorators import method_decorator
-from django.views.decorators.csrf import csrf_protect
 from rest_framework import exceptions, mixins, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
@@ -13,7 +11,6 @@ from .reporting.cache import DocxReportCache, ExcelReportCache
 from .reporting.docx import add_update_url
 
 
-@method_decorator(csrf_protect, name="dispatch")
 class AnalysisViewset(mixins.RetrieveModelMixin, viewsets.GenericViewSet):
     serializer_class = serializers.AnalysisSerializer
     queryset = models.Analysis.objects.all()

--- a/bmds_server/common/auth.py
+++ b/bmds_server/common/auth.py
@@ -20,12 +20,3 @@ class SessionCsrfAuthentication(authentication.SessionAuthentication):
 
         # CSRF passed with authenticated user
         return (user, None)
-
-
-class SafeOrAuthenticatedOrCsrfToken(permissions.BasePermission):
-    def has_permission(self, request, view):
-        return bool(
-            request.method in permissions.SAFE_METHODS
-            or (request.user and request.user.is_authenticated)
-            or getattr(request, "csrf_processing_done", False) is True
-        )

--- a/bmds_server/common/auth.py
+++ b/bmds_server/common/auth.py
@@ -1,0 +1,31 @@
+from rest_framework import authentication, permissions
+
+
+class SessionCsrfAuthentication(authentication.SessionAuthentication):
+    """
+    Custom Session auth where CSRF is enforced for anonymous requests.
+    """
+
+    def authenticate(self, request):
+        # Get the session-based user from the underlying HttpRequest object
+        user = getattr(request._request, "user", None)
+
+        # enforce CSRF with user or any non-safe methods
+        if user or request.method not in permissions.SAFE_METHODS:
+            self.enforce_csrf(request)
+
+        # Unauthenticated
+        if not user or not user.is_active:
+            return None
+
+        # CSRF passed with authenticated user
+        return (user, None)
+
+
+class SafeOrAuthenticatedOrCsrfToken(permissions.BasePermission):
+    def has_permission(self, request, view):
+        return bool(
+            request.method in permissions.SAFE_METHODS
+            or (request.user and request.user.is_authenticated)
+            or getattr(request, "csrf_processing_done", False) is True
+        )

--- a/bmds_server/main/settings/base.py
+++ b/bmds_server/main/settings/base.py
@@ -197,7 +197,6 @@ REST_FRAMEWORK = {
         "rest_framework.authentication.TokenAuthentication",
         "bmds_server.common.auth.SessionCsrfAuthentication",
     ),
-    "DEFAULT_PERMISSION_CLASSES": ["bmds_server.common.auth.SafeOrAuthenticatedOrCsrfToken"],
 }
 
 WEBPACK_LOADER = {

--- a/bmds_server/main/settings/base.py
+++ b/bmds_server/main/settings/base.py
@@ -193,7 +193,11 @@ REST_FRAMEWORK = {
         "rest_framework.throttling.UserRateThrottle",
     ),
     "DEFAULT_THROTTLE_RATES": {"anon": "10/minute", "user": "10/minute"},
-    "DEFAULT_AUTHENTICATION_CLASSES": ("rest_framework.authentication.SessionAuthentication",),
+    "DEFAULT_AUTHENTICATION_CLASSES": (
+        "rest_framework.authentication.TokenAuthentication",
+        "bmds_server.common.auth.SessionCsrfAuthentication",
+    ),
+    "DEFAULT_PERMISSION_CLASSES": ["bmds_server.common.auth.SafeOrAuthenticatedOrCsrfToken"],
 }
 
 WEBPACK_LOADER = {

--- a/bmds_server/main/settings/dev.py
+++ b/bmds_server/main/settings/dev.py
@@ -20,7 +20,7 @@ CELERY_TASK_ALWAYS_EAGER = True
 CELERY_TASK_EAGER_PROPAGATES = True
 
 # disable throttling
-REST_FRAMEWORK = {"DEFAULT_THROTTLE_CLASSES": (), "DEFAULT_THROTTLE_RATES": {}}
+REST_FRAMEWORK.update({"DEFAULT_THROTTLE_CLASSES": (), "DEFAULT_THROTTLE_RATES": {}})
 
 try:
     # load local settings from `local.py` if they exist

--- a/tests/analysis/test_api.py
+++ b/tests/analysis/test_api.py
@@ -225,7 +225,7 @@ class TestOpenApiSchema:
         url = reverse("openapi")
 
         # admin required
-        assert client.get(url).status_code == 403
+        assert client.get(url).status_code == 401
 
         # with admin, success
         client.login(username="admin@bmdsonline.org", password="pw")

--- a/tests/analysis/test_api.py
+++ b/tests/analysis/test_api.py
@@ -59,10 +59,7 @@ class TestAnalysisViewSet:
             response = client.patch(write_url, payload, format="json")
             assert response.status_code == 200
 
-
-@pytest.mark.django_db
-class TestPatchInputs:
-    def test_auth(self):
+    def test_patch_auth(self):
         client = APIClient()
         analysis = Analysis.objects.create()
         url = analysis.get_api_patch_inputs_url()
@@ -86,7 +83,7 @@ class TestPatchInputs:
         assert response.status_code == 400
         assert response.json() == ["A `data` object is required"]
 
-    def test_partial(self):
+    def test_patch_partial(self):
         client = APIClient()
         analysis = Analysis.objects.create()
         url = analysis.get_api_patch_inputs_url()
@@ -135,7 +132,7 @@ class TestPatchInputs:
         assert response.status_code == 200
         assert response.json()["inputs"] == payload["data"]
 
-    def test_complete_continuous(self, bmds3_complete_continuous):
+    def test_patch_complete_continuous(self, bmds3_complete_continuous):
         client = APIClient()
         analysis = Analysis.objects.create()
         url = analysis.get_api_patch_inputs_url()
@@ -146,7 +143,7 @@ class TestPatchInputs:
         assert response.status_code == 200
         assert response.json()["inputs"] == payload["data"]
 
-    def test_complete_dichotomous(self, bmds3_complete_dichotomous):
+    def test_patch_complete_dichotomous(self, bmds3_complete_dichotomous):
         client = APIClient()
         analysis = Analysis.objects.create()
         url = analysis.get_api_patch_inputs_url()
@@ -157,10 +154,7 @@ class TestPatchInputs:
         assert response.status_code == 200
         assert response.json()["inputs"] == payload["data"]
 
-
-@pytest.mark.skipif(not RunBmds3.should_run, reason=RunBmds3.skip_reason)
-@pytest.mark.django_db
-class TestExecute:
+    @pytest.mark.skipif(not RunBmds3.should_run, reason=RunBmds3.skip_reason)
     def test_execute(self, bmds3_complete_dichotomous):
         client = APIClient()
         analysis = Analysis.objects.create(inputs=bmds3_complete_dichotomous)
@@ -181,6 +175,7 @@ class TestExecute:
         assert response.data["has_errors"] is False
         assert bmd == pytest.approx(164.3, rel=0.05)
 
+    @pytest.mark.skipif(not RunBmds3.should_run, reason=RunBmds3.skip_reason)
     def test_reset_execute(self, bmds3_complete_dichotomous):
         client = APIClient()
         analysis = Analysis.objects.create(inputs=bmds3_complete_dichotomous)
@@ -200,10 +195,7 @@ class TestExecute:
         assert response.data["has_errors"] is False
         assert response.data["outputs"] == {}
 
-
-@pytest.mark.skipif(not RunBmds3.should_run, reason=RunBmds3.skip_reason)
-@pytest.mark.django_db
-class TestModelSelection:
+    @pytest.mark.skipif(not RunBmds3.should_run, reason=RunBmds3.skip_reason)
     def test_model_selection(self, bmds3_complete_dichotomous):
         client = APIClient()
         analysis = Analysis.objects.create(inputs=bmds3_complete_dichotomous)

--- a/tests/data/db.yaml
+++ b/tests/data/db.yaml
@@ -414,6 +414,84 @@
     - analysis
     - job
     codename: view_job
+- model: auth.group
+  pk: 1
+  fields:
+    name: base-view
+    permissions:
+    - - view_logentry
+      - admin
+      - logentry
+    - - view_analysis
+      - analysis
+      - analysis
+    - - view_content
+      - analysis
+      - content
+    - - view_job
+      - analysis
+      - job
+    - - view_group
+      - auth
+      - group
+    - - view_permission
+      - auth
+      - permission
+    - - view_user
+      - auth
+      - user
+    - - view_token
+      - authtoken
+      - token
+    - - view_tokenproxy
+      - authtoken
+      - tokenproxy
+    - - view_contenttype
+      - contenttypes
+      - contenttype
+    - - view_revision
+      - reversion
+      - revision
+    - - view_version
+      - reversion
+      - version
+    - - view_session
+      - sessions
+      - session
+- model: auth.group
+  pk: 2
+  fields:
+    name: edit-analyses
+    permissions:
+    - - add_analysis
+      - analysis
+      - analysis
+    - - change_analysis
+      - analysis
+      - analysis
+    - - delete_analysis
+      - analysis
+      - analysis
+    - - view_analysis
+      - analysis
+      - analysis
+- model: auth.group
+  pk: 3
+  fields:
+    name: edit-content
+    permissions:
+    - - add_content
+      - analysis
+      - content
+    - - change_content
+      - analysis
+      - content
+    - - delete_content
+      - analysis
+      - content
+    - - view_content
+      - analysis
+      - content
 - model: auth.user
   pk: 1
   fields:

--- a/tests/data/db.yaml
+++ b/tests/data/db.yaml
@@ -507,6 +507,12 @@
     date_joined: 2020-12-15 23:27:18.235646+00:00
     groups: []
     user_permissions: []
+- model: authtoken.token
+  pk: cef32b9abcbe1a6e9c8460099403e9cd77e12c79
+  fields:
+    user:
+    - admin@bmdsonline.org
+    created: 2021-03-01 22:41:15.270081+00:00
 - model: analysis.analysis
   pk: cc3ca355-a57a-4fba-9dc3-99657562df68
   fields:


### PR DESCRIPTION
Previously, only CSRF token responses were allowed. Now, we also allow for token-based authentication for administrators. In addition:

* Created custom `SessionAuthentication` to check CSRF even for unauthenticated users
* Update test-fixture to include a few authentication groups and a token for admin


