### PR TITLE
Float formatter

### DIFF
--- a/frontend/src/common.js
+++ b/frontend/src/common.js
@@ -48,6 +48,13 @@ export const simulateClick = function(el) {
             return value.toExponential(2);
         }
     },
+    fourDecimalFormatter = function(value) {
+        if (value > 0 && value < 0.0001) {
+            return "<0.0001";
+        } else {
+            return value.toFixed(4);
+        }
+    },
     getLabel = function(value, mapping) {
         return _.find(mapping, d => d.value === value).label;
     };

--- a/frontend/src/common.js
+++ b/frontend/src/common.js
@@ -49,7 +49,9 @@ export const simulateClick = function(el) {
         }
     },
     fourDecimalFormatter = function(value) {
-        if (value > 0 && value < 0.0001) {
+        if (value > 100) {
+            return ff(value);
+        } else if (value > 0 && value < 0.0001) {
             return "<0.0001";
         } else {
             return value.toFixed(4);

--- a/frontend/src/common.js
+++ b/frontend/src/common.js
@@ -1,8 +1,8 @@
 import _ from "lodash";
 import React from "react";
+import {ff, fourDecimalFormatter} from "./utils/formatters";
 
-const BMDS_BLANK_VALUE = -9999;
-
+export {ff, fourDecimalFormatter};
 export const simulateClick = function(el) {
         // https://gomakethings.com/how-to-simulate-a-click-event-with-javascript/
         const evt = new MouseEvent("click", {
@@ -30,32 +30,6 @@ export const simulateClick = function(el) {
     checkOrTimes = bool => {
         // ✓/x in box
         return <i className={bool ? "fa fa-check-square-o" : "fa fa-times-rectangle-o"}></i>;
-    },
-    ff = function(value) {
-        // ff = float format
-        if (value === 0) {
-            return value.toString();
-        } else if (value == BMDS_BLANK_VALUE || !_.isFinite(value)) {
-            return "-";
-        } else if (value > 0 && value < 0.001) {
-            // small things
-            return "<0.001";
-        } else if (Math.abs(value) > 0.001 && Math.abs(value) < 1e5) {
-            // local print "0" for anything smaller than this
-            return value.toLocaleString();
-        } else {
-            // too many 0; use exponential notation
-            return value.toExponential(2);
-        }
-    },
-    fourDecimalFormatter = function(value) {
-        if (value > 100) {
-            return ff(value);
-        } else if (value > 0 && value < 0.0001) {
-            return "<0.0001";
-        } else {
-            return value.toFixed(4);
-        }
     },
     getLabel = function(value, mapping) {
         return _.find(mapping, d => d.value === value).label;

--- a/frontend/src/components/IndividualModel/CSTestofInterest.js
+++ b/frontend/src/components/IndividualModel/CSTestofInterest.js
@@ -2,7 +2,7 @@ import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
 
-import {ff} from "../../common";
+import {ff, fourDecimalFormatter} from "../../common";
 
 @observer
 class CSTestofInterest extends Component {
@@ -30,7 +30,7 @@ class CSTestofInterest extends Component {
                                 <td>{name}</td>
                                 <td>{ff(testInterest.ll_ratios[i])}</td>
                                 <td>{ff(testInterest.dfs[i])}</td>
-                                <td>{ff(testInterest.p_values[i])}</td>
+                                <td>{fourDecimalFormatter(testInterest.p_values[i])}</td>
                             </tr>
                         );
                     })}

--- a/frontend/src/components/IndividualModel/DichotomousDeviance.js
+++ b/frontend/src/components/IndividualModel/DichotomousDeviance.js
@@ -2,7 +2,7 @@ import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
 
-import {ff} from "../../common";
+import {ff, fourDecimalFormatter} from "../../common";
 
 @observer
 class DichotomousDeviance extends Component {
@@ -34,7 +34,7 @@ class DichotomousDeviance extends Component {
                                 <td>{deviances.params[i]}</td>
                                 <td>{ff(deviances.deviance[i])}</td>
                                 <td>{ff(deviances.df[i])}</td>
-                                <td>{ff(deviances.p_value[i])}</td>
+                                <td>{fourDecimalFormatter(deviances.p_value[i])} </td>
                             </tr>
                         );
                     })}

--- a/frontend/src/components/IndividualModel/DichotomousSummary.js
+++ b/frontend/src/components/IndividualModel/DichotomousSummary.js
@@ -2,7 +2,7 @@ import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
 
-import {ff} from "../../common";
+import {ff, fourDecimalFormatter} from "../../common";
 
 @observer
 class DichotomousSummary extends Component {
@@ -44,7 +44,7 @@ class DichotomousSummary extends Component {
                     </tr>
                     <tr>
                         <td>p-value</td>
-                        <td>{ff(results.gof.p_value)}</td>
+                        <td>{fourDecimalFormatter(results.gof.p_value)}</td>
                     </tr>
                     <tr>
                         <td>DOF</td>

--- a/frontend/src/components/IndividualModel/ModelParameters.js
+++ b/frontend/src/components/IndividualModel/ModelParameters.js
@@ -2,7 +2,7 @@ import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
 
-import {ff} from "../../common";
+import {fourDecimalFormatter} from "../../common";
 import {checkOrTimes} from "../../common";
 
 @observer
@@ -27,9 +27,9 @@ class ModelParameters extends Component {
                             <tr key={i}>
                                 <td>{name}</td>
                                 <td>
-                                    {ff(parameters.values[i])}
-                                    <br />({ff(parameters.lower_ci[i])},{ff(parameters.upper_ci[i])}
-                                    )
+                                    {fourDecimalFormatter(parameters.values[i])}
+                                    <br />({fourDecimalFormatter(parameters.lower_ci[i])},
+                                    {fourDecimalFormatter(parameters.upper_ci[i])})
                                 </td>
                                 <td>{checkOrTimes(parameters.bounded[i])}</td>
                             </tr>

--- a/frontend/src/utils/formatters.js
+++ b/frontend/src/utils/formatters.js
@@ -1,0 +1,32 @@
+import _ from "lodash";
+
+const BMDS_BLANK_VALUE = -9999;
+
+export const ff = function(value) {
+        // ff = float format
+        if (value === 0) {
+            return value.toString();
+        } else if (value == BMDS_BLANK_VALUE || !_.isFinite(value)) {
+            return "-";
+        } else if (Math.abs(value) > 0.001 && Math.abs(value) < 1e5) {
+            // local print "0" for anything smaller than this
+            return value.toLocaleString();
+        } else {
+            // too many 0; use exponential notation
+            return value.toExponential(2);
+        }
+    },
+    fourDecimalFormatter = function(value) {
+        // Expected values between 0 and 100; with happy case, returns 4 decimals
+        if (value === 0) {
+            return value.toString();
+        } else if (value == BMDS_BLANK_VALUE || !_.isFinite(value)) {
+            return "-";
+        } else if (Math.abs(value) >= 100) {
+            return ff(value);
+        } else if (value > 0 && value < 0.0001) {
+            return "<0.0001";
+        } else {
+            return value.toFixed(4);
+        }
+    };

--- a/frontend/tests/utils/formatters.test.js
+++ b/frontend/tests/utils/formatters.test.js
@@ -1,0 +1,72 @@
+import {ff, fourDecimalFormatter} from "../../src/utils/formatters";
+import assert from "../helpers";
+
+describe("common", function() {
+    describe("ff", function() {
+        it("formats as expected", function() {
+            // special cases
+            assert.equal(ff(-9999), "-");
+            assert.equal(ff(Infinity), "-");
+            assert.equal(ff(0), "0");
+
+            // normal range
+            assert.equal(ff(1), "1");
+            assert.equal(ff(-1), "-1");
+            assert.equal(ff(1.234), "1.234");
+            assert.equal(ff(10.234), "10.234");
+            assert.equal(ff(100.234), "100.234");
+            assert.equal(ff(1001.234), "1,001.234");
+
+            // big numbers
+            assert.equal(ff(1000), "1,000");
+            assert.equal(ff(10000), "10,000");
+            assert.equal(ff(99999), "99,999");
+            assert.equal(ff(100000), "1.00e+5");
+            assert.equal(ff(123456), "1.23e+5");
+
+            // big negative numbers
+            assert.equal(ff(-1000), "-1,000");
+            assert.equal(ff(-10000), "-10,000");
+            assert.equal(ff(-99999), "-99,999");
+            assert.equal(ff(-100000), "-1.00e+5");
+            assert.equal(ff(-123456), "-1.23e+5");
+
+            // small numbers
+            assert.equal(ff(0.1), "0.1");
+            assert.equal(ff(0.01), "0.01");
+            assert.equal(ff(0.0011), "0.001");
+            assert.equal(ff(0.001), "1.00e-3");
+            assert.equal(ff(0.0001), "1.00e-4");
+            assert.equal(ff(0.0000123), "1.23e-5");
+        });
+    });
+
+    describe("fourDecimalFormatter", function() {
+        it("formats as expected", function() {
+            // special cases
+            assert.equal(fourDecimalFormatter(-9999), "-");
+            assert.equal(fourDecimalFormatter(Infinity), "-");
+            assert.equal(fourDecimalFormatter(0), "0");
+
+            // normal range
+            assert.equal(fourDecimalFormatter(99.9999), "99.9999");
+            assert.equal(fourDecimalFormatter(10.23456), "10.2346");
+            assert.equal(fourDecimalFormatter(1.23456), "1.2346");
+            assert.equal(fourDecimalFormatter(0.23456), "0.2346");
+            assert.equal(fourDecimalFormatter(-0.23456), "-0.2346");
+            assert.equal(fourDecimalFormatter(-10.23456), "-10.2346");
+
+            // big numbers (boundary)
+            assert.equal(fourDecimalFormatter(99.99996), "100.0000");
+            assert.equal(fourDecimalFormatter(100), "100");
+
+            // small numbers
+            assert.equal(fourDecimalFormatter(0.01), "0.0100");
+            assert.equal(fourDecimalFormatter(0.001), "0.0010");
+            assert.equal(fourDecimalFormatter(0.0001), "0.0001");
+            assert.equal(fourDecimalFormatter(0.000099999), "<0.0001");
+            assert.equal(fourDecimalFormatter(0.00001), "<0.0001");
+            assert.equal(fourDecimalFormatter(1e-8), "<0.0001");
+        });
+    });
+});


### PR DESCRIPTION
Add a new float formatter for more predictable values; implements #197 

Currently applied to p-values, and parameter estimates. Can be added to other numerical values as determined by statisticians.