### PR TITLE
clamp multistage/polynomial default degree between 1 and 3

### DIFF
--- a/frontend/src/constants/dataConstants.js
+++ b/frontend/src/constants/dataConstants.js
@@ -242,7 +242,7 @@ export const DATA_CONTINUOUS_SUMMARY = "CS",
     },
     getDefaultDegree = function(dataset) {
         const n = getNumDoseGroups(dataset) - 1;
-        return Math.max(1, Math.min(n, 4));
+        return _.clamp(n, 1, 3);
     },
     getDegreeOptions = function(dataset) {
         const maxDegree = Math.max(Math.min(8, getNumDoseGroups(dataset) - 1), 1);


### PR DESCRIPTION
Previously the default degree `n` would be between 1 and 4, where n is the number of dose groups minus 1. Now it is clamped to between 1 and 3; consistent with the BMDS 3.3 Excel interface.

No changes were made to the possible values, which can be between 1 to 8.