### PR TITLE
standardize p-value layout

### DIFF
--- a/frontend/src/components/IndividualModel/CSTestofInterest.js
+++ b/frontend/src/components/IndividualModel/CSTestofInterest.js
@@ -20,7 +20,9 @@ class CSTestofInterest extends Component {
                         <th>Test</th>
                         <th>Likelihood Ratio</th>
                         <th>DF</th>
-                        <th>P Value</th>
+                        <th>
+                            <i>P</i>-Value
+                        </th>
                     </tr>
                 </thead>
                 <tbody>

--- a/frontend/src/components/IndividualModel/CSTestofInterest.js
+++ b/frontend/src/components/IndividualModel/CSTestofInterest.js
@@ -21,7 +21,7 @@ class CSTestofInterest extends Component {
                         <th>Likelihood Ratio</th>
                         <th>DF</th>
                         <th>
-                            <i>P</i>-Value
+                            <i>p</i>-value
                         </th>
                     </tr>
                 </thead>

--- a/frontend/src/components/IndividualModel/CSTestofInterest.js
+++ b/frontend/src/components/IndividualModel/CSTestofInterest.js
@@ -21,7 +21,7 @@ class CSTestofInterest extends Component {
                         <th>Likelihood Ratio</th>
                         <th>DF</th>
                         <th>
-                            <i>p</i>-value
+                            <i>P</i>-Value
                         </th>
                     </tr>
                 </thead>

--- a/frontend/src/components/IndividualModel/ContinuousSummary.js
+++ b/frontend/src/components/IndividualModel/ContinuousSummary.js
@@ -39,7 +39,7 @@ class ContinuousSummary extends Component {
                         <td>{ff(results.fit.loglikelihood)}</td>
                     </tr>
                     <tr>
-                        <td>model_df</td>
+                        <td>Model DOF</td>
                         <td>{ff(results.fit.model_df)}</td>
                     </tr>
                     <tr>

--- a/frontend/src/components/IndividualModel/DichotomousDeviance.js
+++ b/frontend/src/components/IndividualModel/DichotomousDeviance.js
@@ -22,7 +22,9 @@ class DichotomousDeviance extends Component {
                         <th>Num Params</th>
                         <th>Deviance</th>
                         <th>Test DF</th>
-                        <th>P Value</th>
+                        <th>
+                            <i>P</i>-Value
+                        </th>
                     </tr>
                 </thead>
                 <tbody>

--- a/frontend/src/components/IndividualModel/DichotomousDeviance.js
+++ b/frontend/src/components/IndividualModel/DichotomousDeviance.js
@@ -23,7 +23,7 @@ class DichotomousDeviance extends Component {
                         <th>Deviance</th>
                         <th>Test DF</th>
                         <th>
-                            <i>P</i>-Value
+                            <i>p</i>-value
                         </th>
                     </tr>
                 </thead>

--- a/frontend/src/components/IndividualModel/DichotomousDeviance.js
+++ b/frontend/src/components/IndividualModel/DichotomousDeviance.js
@@ -23,7 +23,7 @@ class DichotomousDeviance extends Component {
                         <th>Deviance</th>
                         <th>Test DF</th>
                         <th>
-                            <i>p</i>-value
+                            <i>P</i>-Value
                         </th>
                     </tr>
                 </thead>

--- a/frontend/src/components/IndividualModel/DichotomousSummary.js
+++ b/frontend/src/components/IndividualModel/DichotomousSummary.js
@@ -40,7 +40,7 @@ class DichotomousSummary extends Component {
                     </tr>
                     <tr>
                         <td>
-                            <i>P</i>-Value
+                            <i>p</i>-value
                         </td>
                         <td>{fourDecimalFormatter(results.gof.p_value)}</td>
                     </tr>

--- a/frontend/src/components/IndividualModel/DichotomousSummary.js
+++ b/frontend/src/components/IndividualModel/DichotomousSummary.js
@@ -40,7 +40,7 @@ class DichotomousSummary extends Component {
                     </tr>
                     <tr>
                         <td>
-                            <i>p</i>-value
+                            <i>P</i>-Value
                         </td>
                         <td>{fourDecimalFormatter(results.gof.p_value)}</td>
                     </tr>

--- a/frontend/src/components/IndividualModel/DichotomousSummary.js
+++ b/frontend/src/components/IndividualModel/DichotomousSummary.js
@@ -39,15 +39,17 @@ class DichotomousSummary extends Component {
                         <td>{ff(results.fit.loglikelihood)}</td>
                     </tr>
                     <tr>
-                        <td>model_df</td>
-                        <td>{ff(results.fit.model_df)}</td>
-                    </tr>
-                    <tr>
-                        <td>p-value</td>
+                        <td>
+                            <i>P</i>-Value
+                        </td>
                         <td>{fourDecimalFormatter(results.gof.p_value)}</td>
                     </tr>
                     <tr>
-                        <td>DOF</td>
+                        <td>Model DOF</td>
+                        <td>{ff(results.fit.model_df)}</td>
+                    </tr>
+                    <tr>
+                        <td>Total DOF</td>
                         <td>{ff(results.fit.total_df)}</td>
                     </tr>
                     <tr>

--- a/frontend/src/components/Logic/RuleRow.js
+++ b/frontend/src/components/Logic/RuleRow.js
@@ -50,7 +50,7 @@ class RuleRow extends Component {
                         value={rule.failure_bin}
                     />
                 </td>
-                <td>{ruleLookup.notes(rule.threshold)}</td>
+                <td dangerouslySetInnerHTML={{__html: ruleLookup.notes(rule.threshold)}} />
             </tr>
         ) : (
             <tr>
@@ -66,7 +66,7 @@ class RuleRow extends Component {
                 </td>
                 <td>{_.isNumber(rule.threshold) ? rule.threshold : "-"}</td>
                 <td>{BIN_NAMES[rule.failure_bin]}</td>
-                <td>{ruleLookup.notes(rule.threshold)}</td>
+                <td dangerouslySetInnerHTML={{__html: ruleLookup.notes(rule.threshold)}} />
             </tr>
         );
     }

--- a/frontend/src/components/Output/BayesianResultTable.js
+++ b/frontend/src/components/Output/BayesianResultTable.js
@@ -36,7 +36,7 @@ class BayesianResultTable extends Component {
                         <th>BMD</th>
                         <th>BMDU</th>
                         <th>
-                            <i>p</i>-value
+                            <i>P</i>-Value
                         </th>
                         <th>Scaled Residual for Dose Group near BMD</th>
                         <th>Scaled Residual for Control Dose Group</th>

--- a/frontend/src/components/Output/BayesianResultTable.js
+++ b/frontend/src/components/Output/BayesianResultTable.js
@@ -35,7 +35,9 @@ class BayesianResultTable extends Component {
                         <th>BMDL</th>
                         <th>BMD</th>
                         <th>BMDU</th>
-                        <th>P Value</th>
+                        <th>
+                            <i>P</i>-Value
+                        </th>
                         <th>Scaled Residual for Dose Group near BMD</th>
                         <th>Scaled Residual for Control Dose Group</th>
                     </tr>

--- a/frontend/src/components/Output/BayesianResultTable.js
+++ b/frontend/src/components/Output/BayesianResultTable.js
@@ -36,7 +36,7 @@ class BayesianResultTable extends Component {
                         <th>BMD</th>
                         <th>BMDU</th>
                         <th>
-                            <i>P</i>-Value
+                            <i>p</i>-value
                         </th>
                         <th>Scaled Residual for Dose Group near BMD</th>
                         <th>Scaled Residual for Control Dose Group</th>

--- a/frontend/src/components/Output/FrequentistResultTable.js
+++ b/frontend/src/components/Output/FrequentistResultTable.js
@@ -249,7 +249,7 @@ class FrequentistResultTable extends Component {
                         <th>BMD</th>
                         <th>BMDU</th>
                         <th>
-                            <i>P</i>-Value
+                            <i>p</i>-value
                         </th>
                         <th>AIC</th>
                         <th>Scaled Residual for Dose Group near BMD</th>

--- a/frontend/src/components/Output/FrequentistResultTable.js
+++ b/frontend/src/components/Output/FrequentistResultTable.js
@@ -248,7 +248,9 @@ class FrequentistResultTable extends Component {
                         <th>BMDL</th>
                         <th>BMD</th>
                         <th>BMDU</th>
-                        <th>P Value</th>
+                        <th>
+                            <i>P</i>-Value
+                        </th>
                         <th>AIC</th>
                         <th>Scaled Residual for Dose Group near BMD</th>
                         <th>Scaled Residual for Control Dose Group</th>

--- a/frontend/src/components/Output/FrequentistResultTable.js
+++ b/frontend/src/components/Output/FrequentistResultTable.js
@@ -249,7 +249,7 @@ class FrequentistResultTable extends Component {
                         <th>BMD</th>
                         <th>BMDU</th>
                         <th>
-                            <i>p</i>-value
+                            <i>P</i>-Value
                         </th>
                         <th>AIC</th>
                         <th>Scaled Residual for Dose Group near BMD</th>

--- a/frontend/src/components/Output/NestedDichotomous/BootstrapResults.js
+++ b/frontend/src/components/Output/NestedDichotomous/BootstrapResults.js
@@ -31,7 +31,7 @@ class BootstrapResult extends Component {
                     </tr>
                     <tr>
                         <th>
-                            Combined <i>P</i>-value
+                            Combined <i>p</i>-value
                         </th>
                         <td>{1}</td>
                     </tr>

--- a/frontend/src/components/Output/NestedDichotomous/BootstrapResults.js
+++ b/frontend/src/components/Output/NestedDichotomous/BootstrapResults.js
@@ -30,7 +30,9 @@ class BootstrapResult extends Component {
                         <td>{1}</td>
                     </tr>
                     <tr>
-                        <th>Combined P-value</th>
+                        <th>
+                            Combined <i>P</i>-value
+                        </th>
                         <td>{1}</td>
                     </tr>
                 </tbody>

--- a/frontend/src/components/Output/NestedDichotomous/BootstrapResults.js
+++ b/frontend/src/components/Output/NestedDichotomous/BootstrapResults.js
@@ -31,7 +31,7 @@ class BootstrapResult extends Component {
                     </tr>
                     <tr>
                         <th>
-                            Combined <i>p</i>-value
+                            Combined <i>P</i>-Value
                         </th>
                         <td>{1}</td>
                     </tr>

--- a/frontend/src/components/Output/NestedDichotomous/BootstrapRuns.js
+++ b/frontend/src/components/Output/NestedDichotomous/BootstrapRuns.js
@@ -14,7 +14,7 @@ class BootstrapRuns extends Component {
                     <tr>
                         <th>Run</th>
                         <th>
-                            <i>p</i>-value
+                            <i>P</i>-Value
                         </th>
                         <th>50th</th>
                         <th>90th</th>

--- a/frontend/src/components/Output/NestedDichotomous/BootstrapRuns.js
+++ b/frontend/src/components/Output/NestedDichotomous/BootstrapRuns.js
@@ -13,7 +13,9 @@ class BootstrapRuns extends Component {
                     </tr>
                     <tr>
                         <th>Run</th>
-                        <th>p-Value</th>
+                        <th>
+                            <i>P</i>-Value
+                        </th>
                         <th>50th</th>
                         <th>90th</th>
                         <th>95th</th>

--- a/frontend/src/components/Output/NestedDichotomous/BootstrapRuns.js
+++ b/frontend/src/components/Output/NestedDichotomous/BootstrapRuns.js
@@ -14,7 +14,7 @@ class BootstrapRuns extends Component {
                     <tr>
                         <th>Run</th>
                         <th>
-                            <i>P</i>-Value
+                            <i>p</i>-value
                         </th>
                         <th>50th</th>
                         <th>90th</th>

--- a/frontend/src/components/Output/NestedDichotomous/ResultTable.js
+++ b/frontend/src/components/Output/NestedDichotomous/ResultTable.js
@@ -34,7 +34,7 @@ class ResultTable extends Component {
                         <th>BMD</th>
                         <th>BMDU</th>
                         <th>
-                            <i>P</i>-Value
+                            <i>p</i>-value
                         </th>
                         <th>AIC</th>
                         <th>Unnormalized Log Posterior Probability</th>

--- a/frontend/src/components/Output/NestedDichotomous/ResultTable.js
+++ b/frontend/src/components/Output/NestedDichotomous/ResultTable.js
@@ -34,7 +34,7 @@ class ResultTable extends Component {
                         <th>BMD</th>
                         <th>BMDU</th>
                         <th>
-                            <i>p</i>-value
+                            <i>P</i>-Value
                         </th>
                         <th>AIC</th>
                         <th>Unnormalized Log Posterior Probability</th>

--- a/frontend/src/components/Output/NestedDichotomous/ResultTable.js
+++ b/frontend/src/components/Output/NestedDichotomous/ResultTable.js
@@ -33,7 +33,9 @@ class ResultTable extends Component {
                         <th>BMDL</th>
                         <th>BMD</th>
                         <th>BMDU</th>
-                        <th>P Value</th>
+                        <th>
+                            <i>P</i>-Value
+                        </th>
                         <th>AIC</th>
                         <th>Unnormalized Log Posterior Probability</th>
                         <th>Scaled Residual for Dose Group near BMD</th>

--- a/frontend/src/constants/logicConstants.js
+++ b/frontend/src/constants/logicConstants.js
@@ -88,7 +88,7 @@ export const RULES = Object.freeze({
             enabledNested: true,
         },
         [RULES.VARIANCE_TYPE]: {
-            notes: val => `Constant variance test failed (Test 2 p-value < ${val})`,
+            notes: val => `Constant variance test failed (Test 2 <i>P</i>-Value < ${val})`,
             name: "Constant Variance",
             hasThreshold: true,
             enabledContinuous: true,
@@ -97,7 +97,7 @@ export const RULES = Object.freeze({
         },
         [RULES.VARIANCE_FIT]: {
             name: "Non-Constant Variance",
-            notes: val => `Non-Constant variance test failed (Test 3 p-value < ${val})`,
+            notes: val => `Non-Constant variance test failed (Test 3 <i>P</i>-Value < ${val})`,
             hasThreshold: true,
             enabledContinuous: true,
             enabledDichotomous: false,
@@ -105,7 +105,7 @@ export const RULES = Object.freeze({
         },
         [RULES.GOF]: {
             name: "Goodness of fit p-test",
-            notes: val => `Goodness of fit p-value < ${val} `,
+            notes: val => `Goodness of fit <i>P</i>-Value < ${val} `,
             hasThreshold: true,
             enabledContinuous: true,
             enabledDichotomous: true,
@@ -113,7 +113,7 @@ export const RULES = Object.freeze({
         },
         [RULES.GOF_CANCER]: {
             name: "Goodness of fit p-test (cancer)",
-            notes: val => `Goodness of fit p-value < ${val}`,
+            notes: val => `Goodness of fit <i>P</i>-Value < ${val}`,
             hasThreshold: true,
             enabledContinuous: false,
             enabledDichotomous: true,

--- a/frontend/src/constants/logicConstants.js
+++ b/frontend/src/constants/logicConstants.js
@@ -88,7 +88,7 @@ export const RULES = Object.freeze({
             enabledNested: true,
         },
         [RULES.VARIANCE_TYPE]: {
-            notes: val => `Constant variance test failed (Test 2 <i>P</i>-Value < ${val})`,
+            notes: val => `Constant variance test failed (Test 2 <i>p</i>-value < ${val})`,
             name: "Constant Variance",
             hasThreshold: true,
             enabledContinuous: true,
@@ -97,7 +97,7 @@ export const RULES = Object.freeze({
         },
         [RULES.VARIANCE_FIT]: {
             name: "Non-Constant Variance",
-            notes: val => `Non-Constant variance test failed (Test 3 <i>P</i>-Value < ${val})`,
+            notes: val => `Non-Constant variance test failed (Test 3 <i>p</i>-value < ${val})`,
             hasThreshold: true,
             enabledContinuous: true,
             enabledDichotomous: false,
@@ -105,7 +105,7 @@ export const RULES = Object.freeze({
         },
         [RULES.GOF]: {
             name: "Goodness of fit p-test",
-            notes: val => `Goodness of fit <i>P</i>-Value < ${val} `,
+            notes: val => `Goodness of fit <i>p</i>-value < ${val} `,
             hasThreshold: true,
             enabledContinuous: true,
             enabledDichotomous: true,
@@ -113,7 +113,7 @@ export const RULES = Object.freeze({
         },
         [RULES.GOF_CANCER]: {
             name: "Goodness of fit p-test (cancer)",
-            notes: val => `Goodness of fit <i>P</i>-Value < ${val}`,
+            notes: val => `Goodness of fit <i>p</i>-value < ${val}`,
             hasThreshold: true,
             enabledContinuous: false,
             enabledDichotomous: true,

--- a/tests/data/db.yaml
+++ b/tests/data/db.yaml
@@ -1614,10 +1614,10 @@
               - '0':
                 - Control stdev. fit greater than threshold (2.312 > 1.5)
                 '1':
-                - Goodness of fit P-Value less than threshold (0 < 0.1)
+                - Goodness of fit p-value less than threshold (0 < 0.1)
                 - Abs(Residual of interest) greater than threshold (2.246 > 2.0)
-                - Variance model poorly fits dataset (P-Value 2 = 0)
-                - Incorrect variance model (P-Value 2 = 0), constant variance selected
+                - Variance model poorly fits dataset (p-value 2 = 0)
+                - Incorrect variance model (p-value 2 = 0), constant variance selected
                 '2': []
               recommended_model_index: null
               recommended_model_variable: null
@@ -7067,10 +7067,10 @@
       2.0, "enabled_dichotomous": true, "enabled_continuous": false, "enabled_nested":
       true}]}, "results": {"recommended_model_index": null, "recommended_model_variable":
       null, "model_bin": [1], "model_notes": [{"0": ["Control stdev. fit greater than
-      threshold (2.312 > 1.5)"], "1": ["Goodness of fit P-Value less than threshold
+      threshold (2.312 > 1.5)"], "1": ["Goodness of fit p-value less than threshold
       (0 < 0.1)", "Abs(Residual of interest) greater than threshold (2.246 > 2.0)",
-      "Variance model poorly fits dataset (P-Value 2 = 0)", "Incorrect variance model
-      (P-Value 2 = 0), constant variance selected"], "2": []}]}}, "selected": {"model_index":
+      "Variance model poorly fits dataset (p-value 2 = 0)", "Incorrect variance model
+      (p-value 2 = 0), constant variance selected"], "2": []}]}}, "selected": {"model_index":
       null, "notes": ""}}, "bayesian": null}]}, "errors": [], "created": "2021-11-15T18:42:28.857Z",
       "started": "2021-11-15T18:42:48.876Z", "ended": "2021-11-15T18:42:49.109Z",
       "deletion_date": "2022-05-14T18:42:49.109Z"}}]'
@@ -7342,10 +7342,10 @@
       2.0, "enabled_dichotomous": true, "enabled_continuous": false, "enabled_nested":
       true}]}, "results": {"recommended_model_index": null, "recommended_model_variable":
       null, "model_bin": [1], "model_notes": [{"0": ["Control stdev. fit greater than
-      threshold (2.312 > 1.5)"], "1": ["Goodness of fit P-Value less than threshold
+      threshold (2.312 > 1.5)"], "1": ["Goodness of fit p-value less than threshold
       (0 < 0.1)", "Abs(Residual of interest) greater than threshold (2.246 > 2.0)",
-      "Variance model poorly fits dataset (P-Value 2 = 0)", "Incorrect variance model
-      (P-Value 2 = 0), constant variance selected"], "2": []}]}}, "selected": {"model_index":
+      "Variance model poorly fits dataset (p-value 2 = 0)", "Incorrect variance model
+      (p-value 2 = 0), constant variance selected"], "2": []}]}}, "selected": {"model_index":
       null, "notes": "No best fitting model selected"}}, "bayesian": null}], "analysis_id":
       "cc3ca355-a57a-4fba-9dc3-99657562df68", "bmds_python_version": "1.0.0.dev",
       "bmds_server_version": "e97fdcfa", "analysis_schema_version": "1.0"}, "errors":

--- a/tests/data/db.yaml
+++ b/tests/data/db.yaml
@@ -1614,10 +1614,10 @@
               - '0':
                 - Control stdev. fit greater than threshold (2.312 > 1.5)
                 '1':
-                - Goodness of fit p-value less than threshold (0 < 0.1)
+                - Goodness of fit P-Value less than threshold (0 < 0.1)
                 - Abs(Residual of interest) greater than threshold (2.246 > 2.0)
-                - Variance model poorly fits dataset (p-value 2 = 0)
-                - Incorrect variance model (p-value 2 = 0), constant variance selected
+                - Variance model poorly fits dataset (P-Value 2 = 0)
+                - Incorrect variance model (P-Value 2 = 0), constant variance selected
                 '2': []
               recommended_model_index: null
               recommended_model_variable: null
@@ -7067,10 +7067,10 @@
       2.0, "enabled_dichotomous": true, "enabled_continuous": false, "enabled_nested":
       true}]}, "results": {"recommended_model_index": null, "recommended_model_variable":
       null, "model_bin": [1], "model_notes": [{"0": ["Control stdev. fit greater than
-      threshold (2.312 > 1.5)"], "1": ["Goodness of fit p-value less than threshold
+      threshold (2.312 > 1.5)"], "1": ["Goodness of fit P-Value less than threshold
       (0 < 0.1)", "Abs(Residual of interest) greater than threshold (2.246 > 2.0)",
-      "Variance model poorly fits dataset (p-value 2 = 0)", "Incorrect variance model
-      (p-value 2 = 0), constant variance selected"], "2": []}]}}, "selected": {"model_index":
+      "Variance model poorly fits dataset (P-Value 2 = 0)", "Incorrect variance model
+      (P-Value 2 = 0), constant variance selected"], "2": []}]}}, "selected": {"model_index":
       null, "notes": ""}}, "bayesian": null}]}, "errors": [], "created": "2021-11-15T18:42:28.857Z",
       "started": "2021-11-15T18:42:48.876Z", "ended": "2021-11-15T18:42:49.109Z",
       "deletion_date": "2022-05-14T18:42:49.109Z"}}]'
@@ -7342,10 +7342,10 @@
       2.0, "enabled_dichotomous": true, "enabled_continuous": false, "enabled_nested":
       true}]}, "results": {"recommended_model_index": null, "recommended_model_variable":
       null, "model_bin": [1], "model_notes": [{"0": ["Control stdev. fit greater than
-      threshold (2.312 > 1.5)"], "1": ["Goodness of fit p-value less than threshold
+      threshold (2.312 > 1.5)"], "1": ["Goodness of fit P-Value less than threshold
       (0 < 0.1)", "Abs(Residual of interest) greater than threshold (2.246 > 2.0)",
-      "Variance model poorly fits dataset (p-value 2 = 0)", "Incorrect variance model
-      (p-value 2 = 0), constant variance selected"], "2": []}]}}, "selected": {"model_index":
+      "Variance model poorly fits dataset (P-Value 2 = 0)", "Incorrect variance model
+      (P-Value 2 = 0), constant variance selected"], "2": []}]}}, "selected": {"model_index":
       null, "notes": "No best fitting model selected"}}, "bayesian": null}], "analysis_id":
       "cc3ca355-a57a-4fba-9dc3-99657562df68", "bmds_python_version": "1.0.0.dev",
       "bmds_server_version": "e97fdcfa", "analysis_schema_version": "1.0"}, "errors":


### PR DESCRIPTION
Always show _p_-value in a consistent format, consistent with the American Statistical Assocation.

https://www.amstat.org/asa/files/pdfs/p-valuestatement.pdf

Consistent with this statement, we will use 3 forms:

1. _P_-Value for title case (table header)
2. _p_-value for standard case in sentences
3. _P_-value for case when the value is the first word in a sentence.


In all cases, the _p_ is italicized where possible.
