### PR TITLE
Parameter formatting

### DIFF
--- a/frontend/src/common.js
+++ b/frontend/src/common.js
@@ -1,8 +1,6 @@
 import _ from "lodash";
 import React from "react";
-import {ff, fourDecimalFormatter} from "./utils/formatters";
 
-export {ff, fourDecimalFormatter};
 export const simulateClick = function(el) {
         // https://gomakethings.com/how-to-simulate-a-click-event-with-javascript/
         const evt = new MouseEvent("click", {

--- a/frontend/src/components/IndividualModel/CDFTable.js
+++ b/frontend/src/components/IndividualModel/CDFTable.js
@@ -3,7 +3,7 @@ import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
 
-import {ff} from "../../common";
+import {ff} from "utils/formatters";
 
 @observer
 class CDFTable extends Component {

--- a/frontend/src/components/IndividualModel/ContinuousDeviance.js
+++ b/frontend/src/components/IndividualModel/ContinuousDeviance.js
@@ -2,7 +2,7 @@ import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
 
-import {ff} from "../../common";
+import {ff} from "utils/formatters";
 
 @observer
 class ContinuousDeviance extends Component {

--- a/frontend/src/components/IndividualModel/ContinuousSummary.js
+++ b/frontend/src/components/IndividualModel/ContinuousSummary.js
@@ -2,7 +2,7 @@ import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
 
-import {ff} from "../../common";
+import {ff} from "utils/formatters";
 
 @observer
 class ContinuousSummary extends Component {

--- a/frontend/src/components/IndividualModel/ContinuousTestOfInterest.js
+++ b/frontend/src/components/IndividualModel/ContinuousTestOfInterest.js
@@ -2,7 +2,7 @@ import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
 
-import {ff, fourDecimalFormatter} from "../../common";
+import {ff, fractionalFormatter} from "utils/formatters";
 
 @observer
 class ContinuousTestOfInterest extends Component {
@@ -32,7 +32,7 @@ class ContinuousTestOfInterest extends Component {
                                 <td>{name}</td>
                                 <td>{ff(testInterest.ll_ratios[i])}</td>
                                 <td>{ff(testInterest.dfs[i])}</td>
-                                <td>{fourDecimalFormatter(testInterest.p_values[i])}</td>
+                                <td>{fractionalFormatter(testInterest.p_values[i])}</td>
                             </tr>
                         );
                     })}

--- a/frontend/src/components/IndividualModel/DichotomousDeviance.js
+++ b/frontend/src/components/IndividualModel/DichotomousDeviance.js
@@ -2,7 +2,7 @@ import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
 
-import {ff, fourDecimalFormatter} from "../../common";
+import {ff, fractionalFormatter} from "utils/formatters";
 
 @observer
 class DichotomousDeviance extends Component {
@@ -36,7 +36,7 @@ class DichotomousDeviance extends Component {
                                 <td>{deviances.params[i]}</td>
                                 <td>{ff(deviances.deviance[i])}</td>
                                 <td>{ff(deviances.df[i])}</td>
-                                <td>{fourDecimalFormatter(deviances.p_value[i])} </td>
+                                <td>{fractionalFormatter(deviances.p_value[i])} </td>
                             </tr>
                         );
                     })}

--- a/frontend/src/components/IndividualModel/DichotomousSummary.js
+++ b/frontend/src/components/IndividualModel/DichotomousSummary.js
@@ -2,7 +2,7 @@ import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
 
-import {ff, fourDecimalFormatter} from "../../common";
+import {ff, fourDecimalFormatter} from "utils/formatters";
 
 @observer
 class DichotomousSummary extends Component {

--- a/frontend/src/components/IndividualModel/GoodnessFit.js
+++ b/frontend/src/components/IndividualModel/GoodnessFit.js
@@ -2,7 +2,7 @@ import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
 
-import {ff} from "../../common";
+import {ff} from "utils/formatters";
 import {Dtype} from "../../constants/dataConstants";
 
 @observer

--- a/frontend/src/components/IndividualModel/MaBenchmarkDose.js
+++ b/frontend/src/components/IndividualModel/MaBenchmarkDose.js
@@ -2,7 +2,7 @@ import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
 
-import {ff} from "../../common";
+import {ff} from "utils/formatters";
 
 @observer
 class MaBenchmarkDose extends Component {

--- a/frontend/src/components/IndividualModel/MaIndividualModels.js
+++ b/frontend/src/components/IndividualModel/MaIndividualModels.js
@@ -2,7 +2,7 @@ import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
 
-import {ff} from "../../common";
+import {ff} from "utils/formatters";
 
 @observer
 class MaIndividualModels extends Component {

--- a/frontend/src/components/IndividualModel/ModelOptionsTable.js
+++ b/frontend/src/components/IndividualModel/ModelOptionsTable.js
@@ -9,7 +9,8 @@ import {
     continuousBmrOptions,
     distTypeOptions,
 } from "../../constants/optionsConstants";
-import {ff, getLabel} from "../../common";
+import {getLabel} from "../../common";
+import {ff} from "utils/formatters";
 
 @observer
 class ModelOptionsTable extends Component {

--- a/frontend/src/components/IndividualModel/ModelParameters.js
+++ b/frontend/src/components/IndividualModel/ModelParameters.js
@@ -3,7 +3,7 @@ import {observer} from "mobx-react";
 import PropTypes from "prop-types";
 
 import {ExponentialM3} from "../../constants/modelConstants";
-import {fourDecimalFormatter} from "../../common";
+import {parameterFormatter} from "../../utils/formatters";
 import {checkOrTimes} from "../../common";
 
 @observer
@@ -36,9 +36,9 @@ class ModelParameters extends Component {
                             <tr key={i}>
                                 <td>{parameters.names[i]}</td>
                                 <td>
-                                    {fourDecimalFormatter(parameters.values[i])}
-                                    <br />({fourDecimalFormatter(parameters.lower_ci[i])},&nbsp;
-                                    {fourDecimalFormatter(parameters.upper_ci[i])})
+                                    {parameterFormatter(parameters.values[i])}
+                                    <br />({parameterFormatter(parameters.lower_ci[i])},&nbsp;
+                                    {parameterFormatter(parameters.upper_ci[i])})
                                 </td>
                                 <td>{checkOrTimes(parameters.bounded[i])}</td>
                             </tr>

--- a/frontend/src/components/IndividualModel/ParameterPriorTable.js
+++ b/frontend/src/components/IndividualModel/ParameterPriorTable.js
@@ -5,7 +5,8 @@ import PropTypes from "prop-types";
 
 import {ExponentialM3} from "../../constants/modelConstants";
 import {isFrequentist, priorTypeLabels} from "../../constants/outputConstants";
-import {ff, getLabel} from "../../common";
+import {getLabel} from "../../common";
+import {ff} from "utils/formatters";
 
 const renderPriorRow = prior => {
         return (

--- a/frontend/src/components/Main/OptionsForm/OptionsReadOnly.js
+++ b/frontend/src/components/Main/OptionsForm/OptionsReadOnly.js
@@ -7,7 +7,8 @@ import {
     continuousBmrOptions,
     distTypeOptions,
 } from "../../../constants/optionsConstants";
-import {ff, getLabel} from "../../../common";
+import {getLabel} from "../../../common";
+import {ff} from "utils/formatters";
 
 const OptionsReadOnly = props => {
     const {options, modelType, idx} = props;

--- a/frontend/src/components/Output/BayesianResultTable.js
+++ b/frontend/src/components/Output/BayesianResultTable.js
@@ -4,7 +4,7 @@ import React, {Component} from "react";
 import PropTypes from "prop-types";
 
 import {maIndex, modelClasses} from "../../constants/outputConstants";
-import {ff} from "../../common";
+import {ff, fractionalFormatter} from "utils/formatters";
 
 @inject("outputStore")
 @observer
@@ -57,8 +57,10 @@ class BayesianResultTable extends Component {
                                         {model.name}
                                     </a>
                                 </td>
-                                <td>{ma ? ff(ma.results.priors[index]) : "-"}</td>
-                                <td>{ma ? ff(ma.results.posteriors[index]) : "-"}</td>
+                                <td>{ma ? fractionalFormatter(ma.results.priors[index]) : "-"}</td>
+                                <td>
+                                    {ma ? fractionalFormatter(ma.results.posteriors[index]) : "-"}
+                                </td>
                                 <td>{ff(model.results.bmdl)}</td>
                                 <td>{ff(model.results.bmd)}</td>
                                 <td>{ff(model.results.bmdu)}</td>

--- a/frontend/src/components/Output/FrequentistResultTable.js
+++ b/frontend/src/components/Output/FrequentistResultTable.js
@@ -4,10 +4,11 @@ import {inject, observer} from "mobx-react";
 import React, {Component} from "react";
 import PropTypes from "prop-types";
 
+import {fractionalFormatter} from "utils/formatters";
 import {MODEL_MULTI_TUMOR} from "../../constants/mainConstants";
 import {BIN_LABELS} from "../../constants/logicConstants";
 import {getPValue, modelClasses, priorClass} from "../../constants/outputConstants";
-import {ff} from "../../common";
+import {ff} from "utils/formatters";
 import Button from "../common/Button";
 
 import Popover from "../common/Popover";
@@ -163,7 +164,7 @@ class FrequentistRow extends Component {
                 <td>{ff(data.model.results.bmdl)}</td>
                 <td>{ff(data.model.results.bmd)}</td>
                 <td>{ff(data.model.results.bmdu)}</td>
-                <td>{ff(getPValue(dataset.dtype, data.model.results))}</td>
+                <td>{fractionalFormatter(getPValue(dataset.dtype, data.model.results))}</td>
                 <td>{ff(data.model.results.fit.aic)}</td>
                 <td>{ff(data.model.results.gof.roi)}</td>
                 <td>{ff(data.model.results.gof.residual[0])}</td>

--- a/frontend/src/components/Output/NestedDichotomous/ResultTable.js
+++ b/frontend/src/components/Output/NestedDichotomous/ResultTable.js
@@ -4,7 +4,7 @@ import React, {Component} from "react";
 import PropTypes from "prop-types";
 
 import {modelClasses} from "../../../constants/outputConstants";
-import {ff} from "../../../common";
+import {ff} from "utils/formatters";
 
 @inject("outputStore")
 @observer

--- a/frontend/src/utils/formatters.js
+++ b/frontend/src/utils/formatters.js
@@ -35,9 +35,21 @@ export const ff = function(value) {
             return value.toString();
         } else if (value == BMDS_BLANK_VALUE || !_.isFinite(value)) {
             return "-";
-        } else if (Math.abs(value) >= 1000 || Math.abs(value) <= 0.01) {
+        } else if (Math.abs(value) >= 1000 || Math.abs(value) <= 0.001) {
             return value.toExponential(3);
         } else {
             return value.toPrecision(4);
+        }
+    },
+    fractionalFormatter = function(value) {
+        // Expected values between 0 and 1
+        if (value == BMDS_BLANK_VALUE || !_.isFinite(value) || value < 0) {
+            return "-";
+        } else if (value === 0) {
+            return value.toString();
+        } else if (value < 0.0001) {
+            return "< 0.0001";
+        } else {
+            return value.toPrecision(3);
         }
     };

--- a/frontend/src/utils/formatters.js
+++ b/frontend/src/utils/formatters.js
@@ -29,4 +29,15 @@ export const ff = function(value) {
         } else {
             return value.toFixed(4);
         }
+    },
+    parameterFormatter = function(value) {
+        if (value === 0) {
+            return value.toString();
+        } else if (value == BMDS_BLANK_VALUE || !_.isFinite(value)) {
+            return "-";
+        } else if (Math.abs(value) >= 1000 || Math.abs(value) <= 0.01) {
+            return value.toExponential(3);
+        } else {
+            return value.toPrecision(4);
+        }
     };

--- a/frontend/tests/utils/formatters.test.js
+++ b/frontend/tests/utils/formatters.test.js
@@ -1,72 +1,139 @@
-import {ff, fourDecimalFormatter} from "../../src/utils/formatters";
+import {
+    ff,
+    fourDecimalFormatter,
+    parameterFormatter,
+    fractionalFormatter,
+} from "../../src/utils/formatters";
 import assert from "../helpers";
+
+const check = function(func, input, output) {
+    assert.equal(func(input), output);
+};
 
 describe("common", function() {
     describe("ff", function() {
         it("formats as expected", function() {
             // special cases
-            assert.equal(ff(-9999), "-");
-            assert.equal(ff(Infinity), "-");
-            assert.equal(ff(0), "0");
+            check(ff, -9999, "-");
+            check(ff, Infinity, "-");
+            check(ff, 0, "0");
 
             // normal range
-            assert.equal(ff(1), "1");
-            assert.equal(ff(-1), "-1");
-            assert.equal(ff(1.234), "1.234");
-            assert.equal(ff(10.234), "10.234");
-            assert.equal(ff(100.234), "100.234");
-            assert.equal(ff(1001.234), "1,001.234");
+            check(ff, 1, "1");
+            check(ff, -1, "-1");
+            check(ff, 1.234, "1.234");
+            check(ff, 10.234, "10.234");
+            check(ff, 100.234, "100.234");
+            check(ff, 1001.234, "1,001.234");
 
             // big numbers
-            assert.equal(ff(1000), "1,000");
-            assert.equal(ff(10000), "10,000");
-            assert.equal(ff(99999), "99,999");
-            assert.equal(ff(100000), "1.00e+5");
-            assert.equal(ff(123456), "1.23e+5");
+            check(ff, 1000, "1,000");
+            check(ff, 10000, "10,000");
+            check(ff, 99999, "99,999");
+            check(ff, 100000, "1.00e+5");
+            check(ff, 123456, "1.23e+5");
 
             // big negative numbers
-            assert.equal(ff(-1000), "-1,000");
-            assert.equal(ff(-10000), "-10,000");
-            assert.equal(ff(-99999), "-99,999");
-            assert.equal(ff(-100000), "-1.00e+5");
-            assert.equal(ff(-123456), "-1.23e+5");
+            check(ff, -1000, "-1,000");
+            check(ff, -10000, "-10,000");
+            check(ff, -99999, "-99,999");
+            check(ff, -100000, "-1.00e+5");
+            check(ff, -123456, "-1.23e+5");
 
             // small numbers
-            assert.equal(ff(0.1), "0.1");
-            assert.equal(ff(0.01), "0.01");
-            assert.equal(ff(0.0011), "0.001");
-            assert.equal(ff(0.001), "1.00e-3");
-            assert.equal(ff(0.0001), "1.00e-4");
-            assert.equal(ff(0.0000123), "1.23e-5");
+            check(ff, 0.1, "0.1");
+            check(ff, 0.01, "0.01");
+            check(ff, 0.0011, "0.001");
+            check(ff, 0.001, "1.00e-3");
+            check(ff, 0.0001, "1.00e-4");
+            check(ff, 0.0000123, "1.23e-5");
         });
     });
 
     describe("fourDecimalFormatter", function() {
         it("formats as expected", function() {
             // special cases
-            assert.equal(fourDecimalFormatter(-9999), "-");
-            assert.equal(fourDecimalFormatter(Infinity), "-");
-            assert.equal(fourDecimalFormatter(0), "0");
+            check(fourDecimalFormatter, -9999, "-");
+            check(fourDecimalFormatter, Infinity, "-");
+            check(fourDecimalFormatter, 0, "0");
 
             // normal range
-            assert.equal(fourDecimalFormatter(99.9999), "99.9999");
-            assert.equal(fourDecimalFormatter(10.23456), "10.2346");
-            assert.equal(fourDecimalFormatter(1.23456), "1.2346");
-            assert.equal(fourDecimalFormatter(0.23456), "0.2346");
-            assert.equal(fourDecimalFormatter(-0.23456), "-0.2346");
-            assert.equal(fourDecimalFormatter(-10.23456), "-10.2346");
+            check(fourDecimalFormatter, 99.9999, "99.9999");
+            check(fourDecimalFormatter, 10.23456, "10.2346");
+            check(fourDecimalFormatter, 1.23456, "1.2346");
+            check(fourDecimalFormatter, 0.23456, "0.2346");
+            check(fourDecimalFormatter, -0.23456, "-0.2346");
+            check(fourDecimalFormatter, -10.23456, "-10.2346");
 
             // big numbers (boundary)
-            assert.equal(fourDecimalFormatter(99.99996), "100.0000");
-            assert.equal(fourDecimalFormatter(100), "100");
+            check(fourDecimalFormatter, 99.99996, "100.0000");
+            check(fourDecimalFormatter, 100, "100");
 
             // small numbers
-            assert.equal(fourDecimalFormatter(0.01), "0.0100");
-            assert.equal(fourDecimalFormatter(0.001), "0.0010");
-            assert.equal(fourDecimalFormatter(0.0001), "0.0001");
-            assert.equal(fourDecimalFormatter(0.000099999), "<0.0001");
-            assert.equal(fourDecimalFormatter(0.00001), "<0.0001");
-            assert.equal(fourDecimalFormatter(1e-8), "<0.0001");
+            check(fourDecimalFormatter, 0.01, "0.0100");
+            check(fourDecimalFormatter, 0.001, "0.0010");
+            check(fourDecimalFormatter, 0.0001, "0.0001");
+            check(fourDecimalFormatter, 0.000099999, "<0.0001");
+            check(fourDecimalFormatter, 0.00001, "<0.0001");
+            check(fourDecimalFormatter, 1e-8, "<0.0001");
+        });
+    });
+
+    describe("parameterFormatter", function() {
+        it("formats as expected", function() {
+            // special cases
+            check(parameterFormatter, -9999, "-");
+            check(parameterFormatter, Infinity, "-");
+            check(parameterFormatter, 0, "0");
+
+            // normal range
+            check(parameterFormatter, 99.9999, "100.0");
+            check(parameterFormatter, 10.23456, "10.23");
+            check(parameterFormatter, 1.23456, "1.235");
+            check(parameterFormatter, 0.23456, "0.2346");
+            check(parameterFormatter, -0.23456, "-0.2346");
+            check(parameterFormatter, -10.23456, "-10.23");
+
+            // big numbers (boundary)
+            check(parameterFormatter, 99.99996, "100.0");
+            check(parameterFormatter, 100, "100.0");
+
+            // small numbers
+            check(parameterFormatter, 0.01, "0.01000");
+            check(parameterFormatter, 0.001, "1.000e-3");
+            check(parameterFormatter, 0.0001, "1.000e-4");
+            check(parameterFormatter, 0.000099999, "1.000e-4");
+            check(parameterFormatter, 0.00001, "1.000e-5");
+            check(parameterFormatter, 1e-8, "1.000e-8");
+        });
+    });
+
+    describe("fractionalFormatter", function() {
+        it("formats as expected", function() {
+            // special cases
+            assert.equal(fractionalFormatter(-9999), "-");
+            assert.equal(fractionalFormatter(Infinity), "-");
+            assert.equal(fractionalFormatter(0), "0");
+
+            // normal range
+            assert.equal(fractionalFormatter(0.23456), "0.235");
+            assert.equal(fractionalFormatter(0.23456), "0.235");
+            assert.equal(fractionalFormatter(10.23456), "10.2");
+
+            // // big numbers
+            assert.equal(fractionalFormatter(99.9999), "100");
+            assert.equal(fractionalFormatter(10.23456), "10.2");
+            assert.equal(fractionalFormatter(1.23456), "1.23");
+            assert.equal(fractionalFormatter(99.99996), "100");
+            assert.equal(fractionalFormatter(100), "100");
+
+            // small numbers
+            assert.equal(fractionalFormatter(0.01), "0.0100");
+            assert.equal(fractionalFormatter(0.001), "0.00100");
+            assert.equal(fractionalFormatter(0.0001), "0.000100");
+            assert.equal(fractionalFormatter(0.000099999), "< 0.0001");
+            assert.equal(fractionalFormatter(0.00001), "< 0.0001");
+            assert.equal(fractionalFormatter(1e-8), "< 0.0001");
         });
     });
 });


### PR DESCRIPTION
Update parameter formatting by adding a few new utility methods:

- `fractionalFormatter` is expected to be between 0 and 1
-  `parameterFormatter` could effectively be any float value