### PR TITLE
rewrite visualization displays

### DIFF
--- a/frontend/src/components/Data/DatasetTable.js
+++ b/frontend/src/components/Data/DatasetTable.js
@@ -57,7 +57,9 @@ class DatasetTable extends Component {
 
                 <table className="table table-sm table-bordered text-right">
                     <colgroup>
-                        {columnNames.map((d,i) => <col key={i} width={width}/>)}
+                        {columnNames.map((d, i) => (
+                            <col key={i} width={width} />
+                        ))}
                     </colgroup>
                     <thead className="bg-custom">
                         <tr>

--- a/frontend/src/components/Data/DatasetTable.js
+++ b/frontend/src/components/Data/DatasetTable.js
@@ -57,9 +57,7 @@ class DatasetTable extends Component {
 
                 <table className="table table-sm table-bordered text-right">
                     <colgroup>
-                        {_.range(columnNames).map(i => (
-                            <col key={i} width={width}></col>
-                        ))}
+                        {columnNames.map((d,i) => <col key={i} width={width}/>)}
                     </colgroup>
                     <thead className="bg-custom">
                         <tr>

--- a/frontend/src/components/IndividualModel/GoodnessFit.js
+++ b/frontend/src/components/IndividualModel/GoodnessFit.js
@@ -34,7 +34,7 @@ class GoodnessFit extends Component {
                     "Estimated Probability",
                     "Scaled Residual",
                 ],
-                [20, 16, 16, 16, 16, 16, 16],
+                [17, 16, 16, 17, 17, 17],
             ];
         }
         throw Error("Unknown dtype");

--- a/frontend/src/components/IndividualModel/GoodnessFit.js
+++ b/frontend/src/components/IndividualModel/GoodnessFit.js
@@ -88,8 +88,8 @@ class GoodnessFit extends Component {
                                       <td>{dose}</td>
                                       <td>{dataset.ns[i]}</td>
                                       <td>{dataset.incidences[i]}</td>
-                                      <td>{ff(gof.expected[i] / dataset.ns[i])}</td>
                                       <td>{ff(gof.expected[i])}</td>
+                                      <td>{ff(gof.expected[i] / dataset.ns[i])}</td>
                                       <td>{ff(gof.residual[i])}</td>
                                   </tr>
                               );

--- a/frontend/src/components/IndividualModel/ModelOptionsTable.js
+++ b/frontend/src/components/IndividualModel/ModelOptionsTable.js
@@ -41,12 +41,12 @@ class ModelOptionsTable extends Component {
             ];
         } else if (dtype == Dtype.CONTINUOUS || dtype == Dtype.CONTINUOUS_INDIVIDUAL) {
             data = [
-                ["Is Increasing", model.settings.is_increasing],
-                ["Distribution Type", getLabel(model.settings.disttype, distTypeOptions)],
                 ["BMR Type", getLabel(model.settings.bmr_type, continuousBmrOptions)],
                 ["BMRF", ff(model.settings.bmr)],
+                ["Distribution Type", getLabel(model.settings.disttype, distTypeOptions)],
+                ["Direction", model.settings.is_increasing ? "Up" : "Down"],
+                ["Confidence Level", 1 - ff(model.settings.alpha)],
                 ["Tail Probability", ff(model.settings.tail_prob)],
-                ["Alpha", ff(model.settings.alpha)],
                 hasDegrees.has(model.model_class.verbose)
                     ? ["Degree", ff(model.settings.degree)]
                     : null,

--- a/frontend/src/constants/plotting.js
+++ b/frontend/src/constants/plotting.js
@@ -1,6 +1,7 @@
 import _ from "lodash";
 import {Dtype} from "./dataConstants";
 import {continuousErrorBars, dichotomousErrorBars} from "../utils/errorBars";
+import {ff} from "../utils/formatters";
 
 const doseResponseLayout = {
         autosize: true,
@@ -40,6 +41,18 @@ const doseResponseLayout = {
             default:
                 throw `Unknown dtype: ${dataset.dtype}`;
         }
+    },
+    hexToRgbA = (hex, alpha) => {
+        var c;
+        if (/^#([A-Fa-f0-9]{3}){1,2}$/.test(hex)) {
+            c = hex.substring(1).split("");
+            if (c.length == 3) {
+                c = [c[0], c[0], c[1], c[1], c[2], c[2]];
+            }
+            c = "0x" + c.join("");
+            return "rgba(" + [(c >> 16) & 255, (c >> 8) & 255, c & 255].join(",") + `,${alpha})`;
+        }
+        throw new Error("Bad Hex");
     };
 
 export const getDoseLabel = function(dataset) {
@@ -141,50 +154,61 @@ export const getDoseLabel = function(dataset) {
         };
     },
     getDrBmdLine = function(model, hexColor) {
-        const annotations = [];
-        if (model.results.bmd) {
-            // https://plotly.com/javascript/reference/layout/annotations/#layout-annotations
-            annotations.push({
-                x: model.results.bmd,
-                y: model.results.plotting.bmd_y,
-                text: "BMD",
-                showarrow: true,
-                arrowhead: 6,
-                arrowsize: 1.5,
-                arrowcolor: hexColor,
-                ax: 0,
-                ay: -30,
-                ayref: "pixel",
-                bgcolor: "white",
-            });
-        }
-        if (model.results.bmdl) {
-            // TODO - more defensively check if bmdl and/or bmdu - change to error bars on line?
-            annotations.push({
-                x: model.results.bmdl,
-                y: model.results.plotting.bmd_y,
-                text: "",
-                arrowside: "none",
-                arrowcolor: hexColor,
-                arrowwidth: 3,
-                ax: model.results.bmdu - model.results.bmdl, // TODO - fix -- too wide?
-                ay: 0,
-                axref: "ax",
-                bgcolor: "white",
+        // https://plotly.com/python/marker-style/
+        // https://plotly.com/javascript/reference/layout/annotations/#layout-annotations
+        // https://plotly.com/javascript/reference/scatter/
+        const hasBmd = model.results.bmd > 0,
+            hasBmdl = model.results.bmdl > 0,
+            hasBmdu = model.results.bmdu > 0,
+            data = [
+                {
+                    x: model.results.plotting.dr_x,
+                    y: model.results.plotting.dr_y,
+                    mode: "lines",
+                    name: model.name,
+                    hoverinfo: "y",
+                    line: {
+                        color: hexToRgbA(hexColor, 0.8),
+                        width: 4,
+                        opacity: 0.5,
+                    },
+                    legendgroup: model.name,
+                },
+            ];
+
+        if (hasBmd) {
+            // prettier-ignore
+            const template = `<b>${model.name}</b><br />BMD: ${ff(model.results.bmd)}<br />BMDL: ${ff(model.results.bmdl)}<br />BMDU: ${ff(model.results.bmdu)}<br />BMR: ${ff(model.results.plotting.bmd_y)}<extra></extra>`;
+
+            data.push({
+                x: [model.results.bmd],
+                y: [model.results.plotting.bmd_y],
+                mode: "markers",
+                type: "scatter",
+                hoverinfo: "x",
+                hovertemplate: template,
+                marker: {
+                    color: hexColor,
+                    size: 16,
+                    symbol: "diamond-tall",
+                    line: {
+                        color: "white",
+                        width: 2,
+                    },
+                },
+                legendgroup: model.name,
+                showlegend: false,
+                error_x: {
+                    array: [hasBmdu ? model.results.bmdu - model.results.bmd : 0],
+                    arrayminus: [hasBmdl ? model.results.bmd - model.results.bmdl : 0],
+                    color: hexToRgbA(hexColor, 0.6),
+                    thickness: 12,
+                    width: 0,
+                },
             });
         }
 
-        return {
-            x: model.results.plotting.dr_x,
-            y: model.results.plotting.dr_y,
-            mode: "lines",
-            name: model.name,
-            line: {
-                color: hexColor,
-                width: 4,
-            },
-            annotations,
-        };
+        return data;
     },
     getBayesianBMDLine = function(model, hexColor) {
         const annotations = [];

--- a/frontend/src/constants/plotting.js
+++ b/frontend/src/constants/plotting.js
@@ -159,17 +159,17 @@ export const getDoseLabel = function(dataset) {
             });
         }
         if (model.results.bmdl) {
+            // TODO - more defensively check if bmdl and/or bmdu - change to error bars on line?
             annotations.push({
                 x: model.results.bmdl,
-                y: model.results.plotting.bmdl_y,
-                text: "BMDL",
-                showarrow: true,
-                arrowhead: 6,
-                arrowsize: 1.5,
+                y: model.results.plotting.bmd_y,
+                text: "",
+                arrowside: "none",
                 arrowcolor: hexColor,
-                ax: 0,
-                ay: -30,
-                ayref: "pixel",
+                arrowwidth: 3,
+                ax: model.results.bmdu - model.results.bmdl, // TODO - fix -- too wide?
+                ay: 0,
+                axref: "ax",
                 bgcolor: "white",
             });
         }
@@ -188,6 +188,7 @@ export const getDoseLabel = function(dataset) {
     },
     getBayesianBMDLine = function(model, hexColor) {
         const annotations = [];
+        // TODO - implement here
         if (model.results.bmd) {
             // https://plotly.com/javascript/reference/layout/annotations/#layout-annotations
             annotations.push({

--- a/frontend/src/stores/OutputStore.js
+++ b/frontend/src/stores/OutputStore.js
@@ -9,6 +9,8 @@ import {
     getDrBmdLine,
     colorCodes,
     bmaColor,
+    hoverColor,
+    selectedColor,
     getBayesianBMDLine,
     getLollipopDataset,
     getLollipopPlotLayout,
@@ -127,7 +129,7 @@ class OutputStore {
         const output = this.selectedOutput;
         if (output && output.frequentist && _.isNumber(output.frequentist.selected.model_index)) {
             const model = output.frequentist.models[output.frequentist.selected.model_index];
-            return getDrBmdLine(model, "#4a9f2f");
+            return getDrBmdLine(model, selectedColor);
         }
         return null;
     }
@@ -155,7 +157,7 @@ class OutputStore {
             !this.drModelModalIsMA &&
             (!this.drModelSelected || this.drModelSelected[0].name !== model.name)
         ) {
-            this.drModelModal = getDrBmdLine(model, "#0000FF");
+            this.drModelModal = getDrBmdLine(model, hoverColor);
         }
         this.showModelModal = true;
     }
@@ -240,17 +242,14 @@ class OutputStore {
         });
         if (output.bayesian.model_average) {
             let bma_data = getBayesianBMDLine(output.bayesian.model_average, bmaColor);
-            bayesian_plot_data.push(bma_data);
+            bayesian_plot_data.push(...bma_data);
         }
         return bayesian_plot_data;
     }
     @computed get drBayesianPlotLayout() {
         // the bayesian plot shown on the output page and modal
-        let layout = _.cloneDeep(this.drFrequentistPlotLayout),
-            output = this.selectedOutput;
-        layout.annotations = output.bayesian.model_average
-            ? getBayesianBMDLine(output.bayesian.model_average, bmaColor).annotations
-            : [];
+        const layout = _.cloneDeep(this.drFrequentistPlotLayout);
+        layout.legend = {tracegroupgap: 0, x: 1, y: 1};
         return layout;
     }
     @computed get drPlotModalData() {
@@ -267,7 +266,7 @@ class OutputStore {
         if (this.drModelSelected && this.drModelSelected[0].name === model.name) {
             return;
         }
-        this.drModelHover = getDrBmdLine(model, "#DA2CDA");
+        this.drModelHover = getDrBmdLine(model, hoverColor);
     }
     @action.bound drPlotRemoveHover() {
         this.drModelHover = null;

--- a/frontend/src/stores/OutputStore.js
+++ b/frontend/src/stores/OutputStore.js
@@ -153,7 +153,7 @@ class OutputStore {
         this.drModelModalIsMA = index === maIndex;
         if (
             !this.drModelModalIsMA &&
-            (!this.drModelSelected || this.drModelSelected.name !== model.name)
+            (!this.drModelSelected || this.drModelSelected[0].name !== model.name)
         ) {
             this.drModelModal = getDrBmdLine(model, "#0000FF");
         }
@@ -174,13 +174,13 @@ class OutputStore {
         // a single model, shown in the modal
         const data = [getDrDatasetPlotData(this.selectedDataset)];
         if (this.showSelectedModelInModalPlot && this.drModelSelected) {
-            data.push(this.drModelSelected);
+            data.push(...this.drModelSelected);
         }
         if (this.drModelModal) {
-            data.push(this.drModelModal);
+            data.push(...this.drModelModal);
         }
         if (this.drModelHover) {
-            data.push(this.drModelHover);
+            data.push(...this.drModelHover);
         }
         return data;
     }
@@ -197,13 +197,13 @@ class OutputStore {
     @computed get drFrequentistPlotData() {
         const data = [getDrDatasetPlotData(this.selectedDataset)];
         if (this.drModelSelected) {
-            data.push(this.drModelSelected);
+            data.push(...this.drModelSelected);
         }
         if (this.drModelModal) {
-            data.push(this.drModelModal);
+            data.push(...this.drModelModal);
         }
         if (this.drModelHover) {
-            data.push(this.drModelHover);
+            data.push(...this.drModelHover);
         }
         return data;
     }
@@ -253,19 +253,18 @@ class OutputStore {
             : [];
         return layout;
     }
-
     @computed get drPlotModalData() {
         const data = [getDrDatasetPlotData(this.selectedDataset)];
         if (this.drModelModal) {
-            data.push(this.drModelModal);
+            data.push(...this.drModelModal);
         }
         if (this.drModelSelected) {
-            data.push(this.drModelSelected);
+            data.push(...this.drModelSelected);
         }
         return data;
     }
     @action.bound drPlotAddHover(model) {
-        if (this.drModelSelected && this.drModelSelected.name === model.name) {
+        if (this.drModelSelected && this.drModelSelected[0].name === model.name) {
             return;
         }
         this.drModelHover = getDrBmdLine(model, "#DA2CDA");


### PR DESCRIPTION
Rewrite BMD and confidence intervals in visualization:
![image](https://user-images.githubusercontent.com/999952/184375210-f0096524-bd0f-489f-9197-d74c08a4008d.png)

Hover display:
![image](https://user-images.githubusercontent.com/999952/184375427-4ceef133-7507-406f-bb8e-137edcf876fb.png)

Additional changes:

- Fix column width for dataset display
- Fix goodness of fit column ordering bug
- Fix goodness of fit css display for dichotomous
- Fix continuous summary details table
