### PR TITLE
update visuals

### DIFF
--- a/frontend/src/constants/plotting.js
+++ b/frontend/src/constants/plotting.js
@@ -188,7 +188,7 @@ export const getDoseLabel = function(dataset) {
                 error_x: {
                     array: [hasBmdu ? model.results.bmdu - model.results.bmd : 0],
                     arrayminus: [hasBmdl ? model.results.bmd - model.results.bmdl : 0],
-                    color: hexToRgbA(hexColor, 0.6),
+                    color: hexToRgbA(hexColor, 0.5),
                     thickness: 18,
                     width: 0,
                 },

--- a/frontend/src/constants/plotting.js
+++ b/frontend/src/constants/plotting.js
@@ -176,8 +176,8 @@ export const getDoseLabel = function(dataset) {
                 hovertemplate: template,
                 marker: {
                     color: hexColor,
-                    size: 16,
-                    symbol: "diamond-tall",
+                    size: 12,
+                    symbol: "circle",
                     line: {
                         color: "white",
                         width: 2,
@@ -189,7 +189,7 @@ export const getDoseLabel = function(dataset) {
                     array: [hasBmdu ? model.results.bmdu - model.results.bmd : 0],
                     arrayminus: [hasBmdl ? model.results.bmd - model.results.bmdl : 0],
                     color: hexToRgbA(hexColor, 0.6),
-                    thickness: 12,
+                    thickness: 18,
                     width: 0,
                 },
             });


### PR DESCRIPTION
Update visuals to change diamonds to thicker bars. Inspired from these excellent [538](https://projects.fivethirtyeight.com/2022-election-forecast/senate/?cid=rrpromo) visuals.

![image](https://user-images.githubusercontent.com/999952/185819157-90696981-4eb4-4791-8769-36e68abbce0c.png)

The 538 visual:
![image](https://user-images.githubusercontent.com/999952/185819212-ddfb2479-76e7-4b54-a399-2ff36d135ba5.png)