### PR TITLE
report caches

### DIFF
--- a/bmds_server/main/settings/base.py
+++ b/bmds_server/main/settings/base.py
@@ -181,7 +181,6 @@ CELERY_WORKER_MAX_TASKS_PER_CHILD = 100
 CELERY_WORKER_PREFETCH_MULTIPLIER = 1
 
 # Cache settings
-ENABLE_REPORT_CACHE = True
 CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",


### PR DESCRIPTION
Report cache for xlsx and docx files are immediately cleared after a successful download. That way, if report options are revised by a user, an older version of a cached report is not used. 

In making this change, we can remove the `ENABLE_REPORT_CACHE` flag. The cache will still be used, but no longer persists after one successful report request cycle (which may be multiple HTTP requests).