### PR TITLE
Option set reporting

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,10 @@ jobs:
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements/*.txt') }}
         restore-keys: |
           ${{ runner.os }}-pip-
+    - name: loc
+      run: |
+        sudo apt-get install -y cloc
+        make loc
     - name: install
       run: |
         mv tests/data/ci-webpack-stats.json bmds_server/webpack-stats.json

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build clean clean-test clean-pyc clean-build docs help lint lint-py lint-js format format-py format-js sync-dev
+.PHONY: build clean clean-test clean-pyc clean-build docs loc help lint lint-py lint-js format format-py format-js sync-dev
 .DEFAULT_GOAL := help
 
 define BROWSER_PYSCRIPT
@@ -61,6 +61,14 @@ docs: ## generate Sphinx HTML documentation, including API docs
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
 	$(BROWSER) docs/_build/html/index.html
+
+loc: ## Generate lines of code report
+	@cloc \
+		--exclude-dir=build,dist,migrations,node_modules,logs,private,public,scripts,vendor,venv \
+		--exclude-ext=json,yaml,svg,toml,ini \
+		--vcs=git \
+		--counted loc-files.txt \
+		.
 
 lint: lint-py lint-js  ## Check for javascript/python for linting issues
 

--- a/bmds_server/__init__.py
+++ b/bmds_server/__init__.py
@@ -1,15 +1,9 @@
 import os
-import platform
 import sys
 
 
 def manage():
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "bmds_server.main.settings.dev")
     from django.core.management import execute_from_command_line
-
-    # Setuptools generate entry point scripts with "-script.py" appended
-    # to the end of them in Windows
-    if platform.system() == "Windows":
-        sys.argv[0] += "-script.py"
 
     execute_from_command_line(sys.argv)

--- a/bmds_server/analysis/reporting/docx.py
+++ b/bmds_server/analysis/reporting/docx.py
@@ -78,6 +78,7 @@ def build_docx(
             dataset_format_long=dataset_format_long,
             all_models=all_models,
             bmd_cdf_table=bmd_cdf_table,
+            session_inputs_table=True,
         )
 
     write_citation(report, 1)

--- a/frontend/src/components/Data/SelectModelType.js
+++ b/frontend/src/components/Data/SelectModelType.js
@@ -15,7 +15,8 @@ class SelectModelType extends Component {
             <div className="model-type mb-2">
                 <Button
                     className="btn btn-primary btn-sm float-right"
-                    disabled={dataStore.checkDatasetsLength}
+                    title="Can add up to 6 datasets"
+                    disabled={!dataStore.canAddNewDataset}
                     faClass="fa fa-fw fa-plus-square"
                     text="New"
                     onClick={dataStore.addDataset}

--- a/frontend/src/components/IndividualModel/GoodnessFit.js
+++ b/frontend/src/components/IndividualModel/GoodnessFit.js
@@ -4,47 +4,39 @@ import PropTypes from "prop-types";
 
 import {ff} from "utils/formatters";
 import {Dtype} from "../../constants/dataConstants";
+import {isLognormal} from "../../constants/modelConstants";
+
+/* eslint-disable */
+const hdr_c_normal = [
+        "Dose", "Size", "Observed Mean", "Calculated Median", "Estimated Median",
+        "Observed SD", "Calculated SD", "Estimated SD", "Scaled Residual",
+    ],
+    hdr_c_lognormal = [
+        "Dose", "Size", "Observed Mean", "Calculated Median", "Estimated Median",
+        "Observed GSD", "Calculated GSD", "Estimated GSD", "Scaled Residual",
+    ],
+    hdr_d = [ "Dose", "Size", "Observed", "Expected", "Estimated Probability", "Scaled Residual"];
+/* eslint-enable */
 
 @observer
 class GoodnessFit extends Component {
-    getHeaders(dtype) {
+    getHeaders(dtype, settings) {
         if (dtype == Dtype.CONTINUOUS || dtype == Dtype.CONTINUOUS_INDIVIDUAL) {
-            return [
-                [
-                    "Dose",
-                    "Size",
-                    "Observed Mean",
-                    "Calculated Median",
-                    "Estimated Median",
-                    "Observed SD",
-                    "Calculated SD",
-                    "Estimated SD",
-                    "Scaled Residual",
-                ],
-                [10, 10, 10, 12, 12, 12, 10, 12, 12],
-            ];
+            const headers = isLognormal(settings.disttype) ? hdr_c_lognormal : hdr_c_normal;
+            return [headers, [10, 10, 10, 12, 12, 12, 10, 12, 12]];
         }
         if (dtype == Dtype.DICHOTOMOUS) {
-            return [
-                [
-                    "Dose",
-                    "Size",
-                    "Observed",
-                    "Expected",
-                    "Estimated Probability",
-                    "Scaled Residual",
-                ],
-                [17, 16, 16, 17, 17, 17],
-            ];
+            return [hdr_d, [17, 16, 16, 17, 17, 17]];
         }
         throw Error("Unknown dtype");
     }
     render() {
         const {store} = this.props,
+            settings = store.modalModel.settings,
             gof = store.modalModel.results.gof,
             dataset = store.selectedDataset,
             {dtype} = dataset,
-            headers = this.getHeaders(dtype);
+            headers = this.getHeaders(dtype, settings);
         return (
             <table className="table table-sm table-bordered text-right">
                 <colgroup>

--- a/frontend/src/components/IndividualModel/GoodnessFit.js
+++ b/frontend/src/components/IndividualModel/GoodnessFit.js
@@ -8,7 +8,7 @@ import {isLognormal} from "../../constants/modelConstants";
 
 /* eslint-disable */
 const hdr_c_normal = [
-        "Dose", "Size", "Observed Mean", "Calculated Median", "Estimated Median",
+        "Dose", "Size", "Observed Mean", "Calculated Mean", "Estimated Mean",
         "Observed SD", "Calculated SD", "Estimated SD", "Scaled Residual",
     ],
     hdr_c_lognormal = [

--- a/frontend/src/components/IndividualModel/GoodnessFit.js
+++ b/frontend/src/components/IndividualModel/GoodnessFit.js
@@ -13,7 +13,7 @@ const hdr_c_normal = [
     ],
     hdr_c_lognormal = [
         "Dose", "Size", "Observed Mean", "Calculated Median", "Estimated Median",
-        "Observed GSD", "Calculated GSD", "Estimated GSD", "Scaled Residual",
+        "Observed SD", "Calculated GSD", "Estimated GSD", "Scaled Residual",
     ],
     hdr_d = [ "Dose", "Size", "Observed", "Expected", "Estimated Probability", "Scaled Residual"];
 /* eslint-enable */

--- a/frontend/src/components/Logic/DecisionLogic.js
+++ b/frontend/src/components/Logic/DecisionLogic.js
@@ -48,17 +48,20 @@ class DecisionLogic extends Component {
                         <table id="decision-logic" className="table table-sm table-bordered">
                             <thead>
                                 <tr className="bg-custom">
-                                    <th colSpan="2">Decision-Logic</th>
+                                    <th colSpan="2">Decision Logic</th>
                                 </tr>
                             </thead>
                             <tbody>
-                                {renderBooleanRow("Enabled", "enabled")}
                                 {renderBooleanRow(
-                                    "Recommend model in Viable Bin",
+                                    "Enable model recommendation logic testing",
+                                    "enabled"
+                                )}
+                                {renderBooleanRow(
+                                    "Recommend model in viable bin",
                                     "recommend_viable"
                                 )}
                                 {renderBooleanRow(
-                                    "Recommend model in Questionable Bin",
+                                    "Recommend model in questionable bin",
                                     "recommend_questionable"
                                 )}
                                 <tr>

--- a/frontend/src/components/Logic/RuleTable.js
+++ b/frontend/src/components/Logic/RuleTable.js
@@ -18,9 +18,7 @@ class RuleList extends Component {
             <table id="rule-table" className="table table-sm table-bordered">
                 <thead className="bg-custom">
                     <tr>
-                        <th colSpan="5" className="text-center">
-                            Model Recommendation/Bin Placement Logic
-                        </th>
+                        <th colSpan="5">Model Recommendation and Bin Placement Logic</th>
                     </tr>
                     <tr>
                         <th>Test Description</th>

--- a/frontend/src/components/Main/OptionsForm/OptionsFormList.js
+++ b/frontend/src/components/Main/OptionsForm/OptionsFormList.js
@@ -74,6 +74,7 @@ class OptionsFormList extends Component {
                                     {optionsStore.canEdit ? (
                                         <th>
                                             <Button
+                                                title="Can add up to 6 option sets"
                                                 className="btn btn-primary"
                                                 disabled={!optionsStore.canAddNewOption}
                                                 onClick={optionsStore.addOptions}

--- a/frontend/src/components/Navigation.js
+++ b/frontend/src/components/Navigation.js
@@ -1,5 +1,5 @@
 import React, {Component} from "react";
-import {Route, NavLink} from "react-router-dom";
+import {Redirect, Route, NavLink} from "react-router-dom";
 import {inject, observer} from "mobx-react";
 import Main from "./Main/Main";
 import DataTab from "./Data/DataTab";
@@ -57,6 +57,9 @@ class Navigation extends Component {
                     <Route path="/data" component={DataTab} />
                     <Route path="/logic" component={LogicRoot} />
                     <Route path="/output" component={Output} />
+                    <Route path="*">
+                        <Redirect to="/" />
+                    </Route>
                 </div>
                 <div className="toast-container">
                     {/* put toasts at the end so it's above everything else */}

--- a/frontend/src/components/Output/BayesianResultTable.js
+++ b/frontend/src/components/Output/BayesianResultTable.js
@@ -17,7 +17,7 @@ class BayesianResultTable extends Component {
             return null;
         }
 
-        const colWidths = [14, 12, 12, 12, 12, 12, 13, 13],
+        const colWidths = [12, 11, 11, 11, 11, 11, 11, 11, 11],
             ma = selectedBayesian.model_average;
 
         return (
@@ -35,6 +35,7 @@ class BayesianResultTable extends Component {
                         <th>BMDL</th>
                         <th>BMD</th>
                         <th>BMDU</th>
+                        <th>Unnormalized Log Posterior Probability</th>
                         <th>Scaled Residual for Dose Group near BMD</th>
                         <th>Scaled Residual for Control Dose Group</th>
                     </tr>
@@ -61,6 +62,7 @@ class BayesianResultTable extends Component {
                                 <td>{ff(model.results.bmdl)}</td>
                                 <td>{ff(model.results.bmd)}</td>
                                 <td>{ff(model.results.bmdu)}</td>
+                                <td>{ff(model.results.fit.bic_equiv)}</td>
                                 <td>{ff(model.results.gof.roi)}</td>
                                 <td>{ff(model.results.gof.residual[0])}</td>
                             </tr>
@@ -84,6 +86,7 @@ class BayesianResultTable extends Component {
                             <td>{ff(ma.results.bmdl)}</td>
                             <td>{ff(ma.results.bmd)}</td>
                             <td>{ff(ma.results.bmdu)}</td>
+                            <td>-</td>
                             <td>-</td>
                             <td>-</td>
                         </tr>

--- a/frontend/src/components/Output/FrequentistResultTable.js
+++ b/frontend/src/components/Output/FrequentistResultTable.js
@@ -15,7 +15,7 @@ import Popover from "../common/Popover";
 
 const getModelBinLabel = function(output, index) {
         if (output.recommender.results.recommended_model_index == index) {
-            return `Recommended - ${output.recommender.results.recommended_model_variable.toUpperCase()}`;
+            return `Recommended - Lowest ${output.recommender.results.recommended_model_variable.toUpperCase()}`;
         }
         return BIN_LABELS[output.recommender.results.model_bin[index]];
     },

--- a/frontend/src/components/Output/OptionSetTable.js
+++ b/frontend/src/components/Output/OptionSetTable.js
@@ -1,0 +1,39 @@
+import {inject, observer} from "mobx-react";
+import React, {Component} from "react";
+import PropTypes from "prop-types";
+
+const data = [
+    ["BMR Type", "Std. Dev."],
+    ["BMR Value", 1],
+    ["Tail Probability", 0.01],
+    ["Confidence Level", 0.95],
+    ["Distribution + Variance", "Normal + Non-constant"],
+    ["Dataset Direction", "Automatic"],
+    ["Maximum Polynomial Degree", 3],
+];
+
+@inject("outputStore")
+@observer
+class OptionSetTable extends Component {
+    render() {
+        return (
+            <table className="table table-sm table-bordered col-r-2">
+                <tbody>
+                    {data.map((d, i) => {
+                        return (
+                            <tr key={i}>
+                                <th>{d[0]}</th>
+                                <td>{d[1]}</td>
+                            </tr>
+                        );
+                    })}
+                </tbody>
+            </table>
+        );
+    }
+}
+OptionSetTable.propTypes = {
+    outputStore: PropTypes.object,
+};
+
+export default OptionSetTable;

--- a/frontend/src/components/Output/OptionSetTable.js
+++ b/frontend/src/components/Output/OptionSetTable.js
@@ -2,33 +2,75 @@ import {inject, observer} from "mobx-react";
 import React, {Component} from "react";
 import PropTypes from "prop-types";
 
-const data = [
-    ["BMR Type", "Std. Dev."],
-    ["BMR Value", 1],
-    ["Tail Probability", 0.01],
-    ["Confidence Level", 0.95],
-    ["Distribution + Variance", "Normal + Non-constant"],
-    ["Dataset Direction", "Automatic"],
-    ["Maximum Polynomial Degree", 3],
-];
+import {MODEL_CONTINUOUS, MODEL_DICHOTOMOUS} from "constants/mainConstants";
+import {adverseDirectionOptions, allDegreeOptions} from "constants/dataConstants";
+import {
+    dichotomousBmrOptions,
+    continuousBmrOptions,
+    distTypeOptions,
+} from "constants/optionsConstants";
+import {ff} from "utils/formatters";
+import {getLabel} from "common";
 
 @inject("outputStore")
 @observer
 class OptionSetTable extends Component {
     render() {
+        const {outputStore} = this.props,
+            {getModelType, selectedModelOptions, selectedDatasetOptions} = outputStore,
+            option_index = outputStore.selectedOutput.option_index + 1;
+        let rows;
+        if (getModelType === MODEL_CONTINUOUS) {
+            rows = [
+                ["BMR Type", getLabel(selectedModelOptions.bmr_type, continuousBmrOptions)],
+                ["BMRF", ff(selectedModelOptions.bmr_value)],
+                ["Distribution Type", getLabel(selectedModelOptions.dist_type, distTypeOptions)],
+                [
+                    "Adverse Direction",
+                    getLabel(selectedDatasetOptions.adverse_direction, adverseDirectionOptions),
+                ],
+                [
+                    "Maximum Polynomial Degree",
+                    getLabel(selectedDatasetOptions.degree, allDegreeOptions),
+                ],
+                ["Tail Probability", ff(selectedModelOptions.tail_probability)],
+                ["Confidence Level", ff(selectedModelOptions.confidence_level)],
+            ];
+        } else if (getModelType === MODEL_DICHOTOMOUS) {
+            rows = [
+                ["BMR Type", getLabel(selectedModelOptions.bmr_type, dichotomousBmrOptions)],
+                ["BMR", ff(selectedModelOptions.bmr_value)],
+                ["Confidence Level", ff(selectedModelOptions.confidence_level)],
+                [
+                    "Maximum Multistage Degree",
+                    getLabel(selectedDatasetOptions.degree, allDegreeOptions),
+                ],
+            ];
+        } else {
+            throw `Unknown model type: ${getModelType}`;
+        }
         return (
-            <table className="table table-sm table-bordered col-r-2">
-                <tbody>
-                    {data.map((d, i) => {
-                        return (
-                            <tr key={i}>
-                                <th>{d[0]}</th>
-                                <td>{d[1]}</td>
-                            </tr>
-                        );
-                    })}
-                </tbody>
-            </table>
+            <>
+                <div className="label">
+                    <label>Option Set:&nbsp;</label>#{option_index}
+                </div>
+                <table className="table table-sm table-bordered text-right">
+                    <colgroup>
+                        <col width="60%" />
+                        <col width="40%" />
+                    </colgroup>
+                    <tbody>
+                        {rows.map((d, i) => {
+                            return (
+                                <tr key={i}>
+                                    <th className="bg-custom">{d[0]}</th>
+                                    <td>{d[1]}</td>
+                                </tr>
+                            );
+                        })}
+                    </tbody>
+                </table>
+            </>
         );
     }
 }

--- a/frontend/src/components/Output/Output.js
+++ b/frontend/src/components/Output/Output.js
@@ -97,10 +97,10 @@ class Output extends Component {
                             />
                         </div>
                     ) : null}
-                    <div className="col-lg-6">
+                    <div className="col-lg-5">
                         <DatasetTable dataset={outputStore.selectedDataset} />
                     </div>
-                    <div className="col-lg-4">
+                    <div className="col-lg-5">
                         <OptionSetTable />
                     </div>
                 </div>

--- a/frontend/src/components/Output/Output.js
+++ b/frontend/src/components/Output/Output.js
@@ -117,7 +117,7 @@ class Output extends Component {
                         </div>
                         <div className="align-items-center d-flex col-lg-4">
                             <DoseResponsePlot
-                                onRelayout={outputStore.saveUserPlotSettings}
+                                onRelayout={outputStore.updateUserPlotSettings}
                                 layout={outputStore.drFrequentistPlotLayout}
                                 data={outputStore.drFrequentistPlotData}
                             />
@@ -132,7 +132,7 @@ class Output extends Component {
                         </div>
                         <div className="col-lg-12">
                             <DoseResponsePlot
-                                onRelayout={outputStore.saveUserPlotSettings}
+                                onRelayout={outputStore.updateUserPlotSettings}
                                 layout={outputStore.drBayesianPlotLayout}
                                 data={outputStore.drBayesianPlotData}
                             />

--- a/frontend/src/components/Output/Output.js
+++ b/frontend/src/components/Output/Output.js
@@ -9,6 +9,7 @@ import FrequentistResultTable from "./FrequentistResultTable";
 import NestedDichotomousResultTable from "./NestedDichotomous/ResultTable";
 import BayesianResultTable from "./BayesianResultTable";
 import DatasetTable from "../Data/DatasetTable";
+import OptionSetTable from "./OptionSetTable";
 import SelectModel from "./SelectModel";
 import DoseResponsePlot from "../common/DoseResponsePlot";
 import "./Output.css";
@@ -98,6 +99,9 @@ class Output extends Component {
                     ) : null}
                     <div className="col-lg-6">
                         <DatasetTable dataset={outputStore.selectedDataset} />
+                    </div>
+                    <div className="col-lg-4">
+                        <OptionSetTable />
                     </div>
                 </div>
                 {selectedFrequentist ? (

--- a/frontend/src/constants/logicConstants.js
+++ b/frontend/src/constants/logicConstants.js
@@ -88,8 +88,7 @@ export const RULES = Object.freeze({
             enabledNested: true,
         },
         [RULES.VARIANCE_TYPE]: {
-            notes: val =>
-                `Variance model poorly fits dataset<br/>(<i>p</i>-value 2 < ${val} OR <i>p</i>-value 2 > ${val})`,
+            notes: val => `Incorrect variance model selected<br/>(Test <i>p</i>-value < ${val})`,
             name: "Variance model selection",
             hasThreshold: true,
             enabledContinuous: true,
@@ -98,8 +97,7 @@ export const RULES = Object.freeze({
         },
         [RULES.VARIANCE_FIT]: {
             name: "Variance model fit",
-            notes: val =>
-                `Variance model poorly fits dataset<br/>(<i>p</i>-value 2 < ${val} OR <i>p</i>-value 3 < ${val})`,
+            notes: val => `Variance test failed (Test <i>p</i>-value < ${val})`,
             hasThreshold: true,
             enabledContinuous: true,
             enabledDichotomous: false,

--- a/frontend/src/constants/modelConstants.js
+++ b/frontend/src/constants/modelConstants.js
@@ -72,6 +72,9 @@ const modelsList = {
             frequentist_unrestricted: [],
         },
     },
+    isLognormal = function(disttype) {
+        return disttype == 3;
+    },
     hasDegrees = new Set(["Multistage", "Polynomial"]);
 
-export {allModelOptions, modelsList, models, hasDegrees};
+export {allModelOptions, modelsList, models, hasDegrees, isLognormal};

--- a/frontend/src/stores/DataStore.js
+++ b/frontend/src/stores/DataStore.js
@@ -255,11 +255,8 @@ class DataStore {
             .map(d => d.dataset);
     }
 
-    @computed get checkDatasetsLength() {
-        if (this.datasets.length > 9) {
-            return true;
-        }
-        return false;
+    @computed get canAddNewDataset() {
+        return this.datasets.length < 6;
     }
 
     @computed get hasSelectedDataset() {

--- a/frontend/src/stores/OptionsStore.js
+++ b/frontend/src/stores/OptionsStore.js
@@ -49,7 +49,7 @@ class OptionsStore {
     }
 
     @computed get canAddNewOption() {
-        return this.optionsList.length < 3;
+        return this.optionsList.length < 6;
     }
 }
 

--- a/frontend/src/stores/OutputStore.js
+++ b/frontend/src/stores/OutputStore.js
@@ -33,11 +33,10 @@ class OutputStore {
     @observable drModelModal = null;
     @observable drModelModalIsMA = false;
     @observable drModelAverageModal = false;
-
     @observable showBMDLine = false;
-
     @observable userPlotSettings = {};
     @observable showInlineNotes = false;
+
     @action.bound toggleInlineNotes() {
         this.showInlineNotes = !this.showInlineNotes;
     }
@@ -72,6 +71,7 @@ class OutputStore {
     @computed get outputs() {
         return this.rootStore.mainStore.getExecutionOutputs;
     }
+
     @computed get selectedOutput() {
         const outputs = this.outputs;
         if (!_.isObject(outputs)) {
@@ -79,6 +79,7 @@ class OutputStore {
         }
         return outputs[this.selectedOutputIndex];
     }
+
     @computed get selectedFrequentist() {
         const output = this.selectedOutput;
         if (output && output.frequentist) {
@@ -86,6 +87,7 @@ class OutputStore {
         }
         return null;
     }
+
     @computed get selectedBayesian() {
         const output = this.selectedOutput;
         if (output && output.bayesian) {
@@ -93,9 +95,20 @@ class OutputStore {
         }
         return null;
     }
+
     @computed get selectedDataset() {
         const dataset_index = this.selectedOutput.dataset_index;
         return this.rootStore.dataStore.datasets[dataset_index];
+    }
+
+    @computed get selectedModelOptions() {
+        const index = this.selectedOutput.option_index;
+        return this.rootStore.optionsStore.optionsList[index];
+    }
+
+    @computed get selectedDatasetOptions() {
+        const index = this.selectedOutput.dataset_index;
+        return this.rootStore.dataOptionStore.options[index];
     }
 
     @computed get recommendationEnabled() {
@@ -161,17 +174,20 @@ class OutputStore {
         }
         this.showModelModal = true;
     }
+
     @action.bound closeModal() {
         this.modalModel = null;
         this.drModelModal = null;
         this.showModelModal = false;
     }
+
     // end modal methods
 
     // start dose-response plotting data methods
     @computed get showSelectedModelInModalPlot() {
         return this.modalModelClass === modelClasses.frequentist;
     }
+
     @computed get drIndividualPlotData() {
         // a single model, shown in the modal
         const data = [getDrDatasetPlotData(this.selectedDataset)];
@@ -186,6 +202,7 @@ class OutputStore {
         }
         return data;
     }
+
     @computed get drIndividualPlotLayout() {
         // a single model, shown in the modal
         const selectedModel = this.showSelectedModelInModalPlot ? this.drModelSelected : null;
@@ -196,6 +213,7 @@ class OutputStore {
             this.drModelHover
         );
     }
+
     @computed get drFrequentistPlotData() {
         const data = [getDrDatasetPlotData(this.selectedDataset)];
         if (this.drModelSelected) {
@@ -209,6 +227,7 @@ class OutputStore {
         }
         return data;
     }
+
     @computed get drFrequentistPlotLayout() {
         // the main frequentist plot shown on the output page
         let layout = getDrLayout(
@@ -225,6 +244,7 @@ class OutputStore {
         }
         return layout;
     }
+
     @computed get drBayesianPlotData() {
         const bayesian_plot_data = [getDrDatasetPlotData(this.selectedDataset)],
             output = this.selectedOutput;
@@ -246,12 +266,14 @@ class OutputStore {
         }
         return bayesian_plot_data;
     }
+
     @computed get drBayesianPlotLayout() {
         // the bayesian plot shown on the output page and modal
         const layout = _.cloneDeep(this.drFrequentistPlotLayout);
         layout.legend = {tracegroupgap: 0, x: 1, y: 1};
         return layout;
     }
+
     @computed get drPlotModalData() {
         const data = [getDrDatasetPlotData(this.selectedDataset)];
         if (this.drModelModal) {
@@ -262,15 +284,18 @@ class OutputStore {
         }
         return data;
     }
+
     @action.bound drPlotAddHover(model) {
         if (this.drModelSelected && this.drModelSelected[0].name === model.name) {
             return;
         }
         this.drModelHover = getDrBmdLine(model, hoverColor);
     }
+
     @action.bound drPlotRemoveHover() {
         this.drModelHover = null;
     }
+
     @computed get drFrequentistLollipopPlotDataset() {
         let plotData = [];
         let models = this.selectedOutput.frequentist.models;
@@ -286,6 +311,7 @@ class OutputStore {
         });
         return plotData;
     }
+
     @computed get drBayesianLollipopPlotDataset() {
         let plotData = [];
         let models = this.selectedOutput.bayesian.models;
@@ -315,9 +341,11 @@ class OutputStore {
     @action.bound saveSelectedModelIndex(idx) {
         this.selectedOutput.frequentist.selected.model_index = idx === -1 ? null : idx;
     }
+
     @action.bound saveSelectedIndexNotes(value) {
         this.selectedOutput.frequentist.selected.notes = value.length > 0 ? value : null;
     }
+
     @action.bound saveSelectedModel() {
         const output = this.selectedOutput,
             {csrfToken, editKey} = this.rootStore.mainStore.config.editSettings,

--- a/frontend/src/stores/OutputStore.js
+++ b/frontend/src/stores/OutputStore.js
@@ -34,7 +34,6 @@ class OutputStore {
     @observable drModelModalIsMA = false;
     @observable drModelAverageModal = false;
     @observable showBMDLine = false;
-    @observable userPlotSettings = {};
     @observable showInlineNotes = false;
 
     @action.bound toggleInlineNotes() {
@@ -43,7 +42,7 @@ class OutputStore {
 
     @action.bound setSelectedOutputIndex(output_id) {
         this.selectedOutputIndex = output_id;
-        this.userPlotSettings = {};
+        this.resetUserPlotSettings();
     }
 
     @computed get getModelType() {
@@ -401,7 +400,12 @@ class OutputStore {
         }
     }
 
-    @action.bound saveUserPlotSettings(e) {
+    // persist changes to axes by user for a given output session
+    @observable userPlotSettings = {};
+    @action.bound resetUserPlotSettings(output_id) {
+        this.userPlotSettings = {};
+    }
+    @action.bound updateUserPlotSettings(e) {
         // set user configurable plot settings
         if (_.has(e, "xaxis.range[0]") && _.has(e, "xaxis.range[1]")) {
             this.userPlotSettings["xaxis"] = [e["xaxis.range[0]"], e["xaxis.range[1]"]];

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,8 @@ packages = find:
 [options.entry_points]
 console_scripts =
     manage.py = bmds_server:manage
+    manage = bmds_server:manage
+    bmds = bmds_server:manage
 
 [flake8]
 exclude = docs

--- a/tests/analysis/test_models.py
+++ b/tests/analysis/test_models.py
@@ -2,7 +2,7 @@ import pytest
 
 from bmds_server.analysis.models import Analysis
 from bmds_server.analysis.reporting.docx import build_docx
-from bmds_server.analysis.reporting.excel import build_df
+from bmds_server.analysis.reporting.excel import summary_df, dataset_df, params_df
 
 from .run3 import RunBmds3
 
@@ -29,7 +29,9 @@ class TestBmds3Execution:
 
         # test reporting (for completion)
         build_docx(analysis, "http://bmds-python.com")
-        build_df(analysis)
+        summary_df(analysis)
+        dataset_df(analysis)
+        params_df(analysis)
 
     def test_ci(self, bmds3_complete_continuous_individual):
         analysis = Analysis.objects.create(inputs=bmds3_complete_continuous_individual)
@@ -50,7 +52,9 @@ class TestBmds3Execution:
 
         # test reporting (for completion)
         build_docx(analysis, "http://bmds-python.com")
-        build_df(analysis)
+        summary_df(analysis)
+        dataset_df(analysis)
+        params_df(analysis)
 
     def test_d(self, bmds3_complete_dichotomous):
         analysis = Analysis.objects.create(inputs=bmds3_complete_dichotomous)
@@ -71,4 +75,6 @@ class TestBmds3Execution:
 
         # test reporting (for completion)
         build_docx(analysis, "http://bmds-python.com")
-        build_df(analysis)
+        summary_df(analysis)
+        dataset_df(analysis)
+        params_df(analysis)

--- a/tests/analysis/test_models.py
+++ b/tests/analysis/test_models.py
@@ -2,7 +2,7 @@ import pytest
 
 from bmds_server.analysis.models import Analysis
 from bmds_server.analysis.reporting.docx import build_docx
-from bmds_server.analysis.reporting.excel import summary_df, dataset_df, params_df
+from bmds_server.analysis.reporting.excel import dataset_df, params_df, summary_df
 
 from .run3 import RunBmds3
 

--- a/tests/data/db.yaml
+++ b/tests/data/db.yaml
@@ -1616,7 +1616,7 @@
                 '1':
                 - Goodness of fit p-value less than threshold (0 < 0.1)
                 - Abs(Residual of interest) greater than threshold (2.246 > 2.0)
-                - Variance model poorly fits dataset (p-value 2 = 0)
+                - Variance test failed (Test 2 p-value 2 < 0.05)
                 - Incorrect variance model (p-value 2 = 0), constant variance selected
                 '2': []
               recommended_model_index: null
@@ -7069,7 +7069,7 @@
       null, "model_bin": [1], "model_notes": [{"0": ["Control stdev. fit greater than
       threshold (2.312 > 1.5)"], "1": ["Goodness of fit p-value less than threshold
       (0 < 0.1)", "Abs(Residual of interest) greater than threshold (2.246 > 2.0)",
-      "Variance model poorly fits dataset (p-value 2 = 0)", "Incorrect variance model
+      "Constant variance test failed (p-value 2 < 0.05)", "Incorrect variance model
       (p-value 2 = 0), constant variance selected"], "2": []}]}}, "selected": {"model_index":
       null, "notes": ""}}, "bayesian": null}]}, "errors": [], "created": "2021-11-15T18:42:28.857Z",
       "started": "2021-11-15T18:42:48.876Z", "ended": "2021-11-15T18:42:49.109Z",
@@ -7344,7 +7344,7 @@
       null, "model_bin": [1], "model_notes": [{"0": ["Control stdev. fit greater than
       threshold (2.312 > 1.5)"], "1": ["Goodness of fit p-value less than threshold
       (0 < 0.1)", "Abs(Residual of interest) greater than threshold (2.246 > 2.0)",
-      "Variance model poorly fits dataset (p-value 2 = 0)", "Incorrect variance model
+      "Constant variance test failed (p-value 2 < 0.05)", "Incorrect variance model
       (p-value 2 = 0), constant variance selected"], "2": []}]}}, "selected": {"model_index":
       null, "notes": "No best fitting model selected"}}, "bayesian": null}], "analysis_id":
       "cc3ca355-a57a-4fba-9dc3-99657562df68", "bmds_python_version": "1.0.0.dev",


### PR DESCRIPTION
- Add lines of code to github actions
- Fix setup.py to work with updated pip
- Excel exports update
    - Improve continuous and dichotomous values
    - Add parameters worksheet and dataset worksheet
- Word export updates
    - Add inputs summary table for each session
- Change maximum values; from 3 option sets and 10 datasets, to 6 option sets and 6 datasets
- Update goodness of fit tables to have mean/SD for normal, and median/GSD for lognormal
- Improve language for decision logic values and model recommendations
- Improve javascript SPA app to link to add the home page `/` as the default route
- Add LPP to bayesian summary outputs
- Add option set table for output tables