### PR TITLE
sort JS imports - lint and format 

### DIFF
--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -38,7 +38,9 @@
         "space-before-function-paren": [
             2,
             "never"
-        ]
+        ],
+        "simple-import-sort/imports": "error",
+        "simple-import-sort/exports": "error"
     },
     "parser": "babel-eslint",
     "parserOptions": {
@@ -63,7 +65,8 @@
     "plugins": [
         "babel",
         "react",
-        "prettier"
+        "prettier",
+        "simple-import-sort"
     ],
     "settings": {
         "react": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,6 +46,7 @@
     "eslint-plugin-babel": "^5.3.0",
     "eslint-plugin-prettier": "^3.1.2",
     "eslint-plugin-react": "^7.17.0",
+    "eslint-plugin-simple-import-sort": "^8.0.0",
     "exports-loader": "^0.6.4",
     "express": "^4.16.2",
     "html-webpack-plugin": "^4.0.4",

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,8 +1,8 @@
-import React, {Component} from "react";
-import {HashRouter} from "react-router-dom";
+import {autorun} from "mobx";
 import {inject, observer} from "mobx-react";
 import PropTypes from "prop-types";
-import {autorun} from "mobx";
+import React, {Component} from "react";
+import {HashRouter} from "react-router-dom";
 
 import Navigation from "./components/Navigation";
 

--- a/frontend/src/components/Data/DataTab.js
+++ b/frontend/src/components/Data/DataTab.js
@@ -1,12 +1,12 @@
-import React, {Component} from "react";
 import {inject, observer} from "mobx-react";
 import PropTypes from "prop-types";
+import React, {Component} from "react";
 
+import DoseResponsePlot from "../common/DoseResponsePlot";
 import DatasetForm from "./DatasetForm";
 import DatasetSelector from "./DatasetSelector";
-import SelectModelType from "./SelectModelType";
-import DoseResponsePlot from "../common/DoseResponsePlot";
 import DatasetTable from "./DatasetTable";
+import SelectModelType from "./SelectModelType";
 
 @inject("dataStore")
 @observer

--- a/frontend/src/components/Data/DatasetForm.js
+++ b/frontend/src/components/Data/DatasetForm.js
@@ -1,12 +1,12 @@
-import React, {Component} from "react";
 import {inject, observer} from "mobx-react";
 import PropTypes from "prop-types";
-import TabularDatasetModal from "./TabularDatasetModal";
+import React, {Component} from "react";
 
 import {columnHeaders, columns} from "../../constants/dataConstants";
-import TextInput from "../common/TextInput";
-import FloatInput from "../common/FloatInput";
 import Button from "../common/Button";
+import FloatInput from "../common/FloatInput";
+import TextInput from "../common/TextInput";
+import TabularDatasetModal from "./TabularDatasetModal";
 
 const DatasetFormRow = props => {
     return (

--- a/frontend/src/components/Data/DatasetSelector.js
+++ b/frontend/src/components/Data/DatasetSelector.js
@@ -1,6 +1,6 @@
-import React, {Component} from "react";
 import {inject, observer} from "mobx-react";
 import PropTypes from "prop-types";
+import React, {Component} from "react";
 
 import SelectInput from "../common/SelectInput";
 

--- a/frontend/src/components/Data/DatasetTable.js
+++ b/frontend/src/components/Data/DatasetTable.js
@@ -1,9 +1,9 @@
 import _ from "lodash";
-import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
+import React, {Component} from "react";
 
-import {columns, columnHeaders} from "../../constants/dataConstants";
+import {columnHeaders, columns} from "../../constants/dataConstants";
 import {Dtype} from "../../constants/dataConstants";
 
 const dataRows = (dataset, columnNames) => {

--- a/frontend/src/components/Data/SelectModelType.js
+++ b/frontend/src/components/Data/SelectModelType.js
@@ -1,10 +1,10 @@
-import React, {Component} from "react";
 import {inject, observer} from "mobx-react";
 import PropTypes from "prop-types";
+import React, {Component} from "react";
 
-import SelectInput from "../common/SelectInput";
-import LabelInput from "../common/LabelInput";
 import Button from "../common/Button";
+import LabelInput from "../common/LabelInput";
+import SelectInput from "../common/SelectInput";
 
 @inject("dataStore")
 @observer

--- a/frontend/src/components/Data/TabularDatasetModal.js
+++ b/frontend/src/components/Data/TabularDatasetModal.js
@@ -1,9 +1,9 @@
-import React, {Component} from "react";
 import {inject, observer} from "mobx-react";
 import PropTypes from "prop-types";
+import React, {Component} from "react";
 import {Modal} from "react-bootstrap";
-import Button from "../common/Button";
 
+import Button from "../common/Button";
 import TextAreaInput from "../common/TextAreaInput";
 
 @inject("dataStore")

--- a/frontend/src/components/IndividualModel/CDFPlot.js
+++ b/frontend/src/components/IndividualModel/CDFPlot.js
@@ -1,8 +1,9 @@
-import React, {Component} from "react";
-import {observer} from "mobx-react";
-import Plot from "react-plotly.js";
-import PropTypes from "prop-types";
 import {toJS} from "mobx";
+import {observer} from "mobx-react";
+import PropTypes from "prop-types";
+import React, {Component} from "react";
+import Plot from "react-plotly.js";
+
 import {getCdfLayout, getConfig} from "../../constants/plotting";
 
 @observer

--- a/frontend/src/components/IndividualModel/CDFTable.js
+++ b/frontend/src/components/IndividualModel/CDFTable.js
@@ -1,8 +1,7 @@
 import _ from "lodash";
-import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
-
+import React, {Component} from "react";
 import {ff} from "utils/formatters";
 
 @observer

--- a/frontend/src/components/IndividualModel/CDFTable.js
+++ b/frontend/src/components/IndividualModel/CDFTable.js
@@ -2,7 +2,8 @@ import _ from "lodash";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
 import React, {Component} from "react";
-import {ff} from "utils/formatters";
+
+import {ff} from "@/utils/formatters";
 
 @observer
 class CDFTable extends Component {

--- a/frontend/src/components/IndividualModel/ContinuousDeviance.js
+++ b/frontend/src/components/IndividualModel/ContinuousDeviance.js
@@ -1,7 +1,6 @@
-import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
-
+import React, {Component} from "react";
 import {ff} from "utils/formatters";
 
 @observer

--- a/frontend/src/components/IndividualModel/ContinuousDeviance.js
+++ b/frontend/src/components/IndividualModel/ContinuousDeviance.js
@@ -1,7 +1,8 @@
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
 import React, {Component} from "react";
-import {ff} from "utils/formatters";
+
+import {ff} from "@/utils/formatters";
 
 @observer
 class ContinuousDeviance extends Component {

--- a/frontend/src/components/IndividualModel/ContinuousSummary.js
+++ b/frontend/src/components/IndividualModel/ContinuousSummary.js
@@ -1,7 +1,6 @@
-import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
-
+import React, {Component} from "react";
 import {ff, fractionalFormatter} from "utils/formatters";
 
 @observer

--- a/frontend/src/components/IndividualModel/ContinuousSummary.js
+++ b/frontend/src/components/IndividualModel/ContinuousSummary.js
@@ -1,7 +1,8 @@
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
 import React, {Component} from "react";
-import {ff, fractionalFormatter} from "utils/formatters";
+
+import {ff, fractionalFormatter} from "@/utils/formatters";
 
 @observer
 class ContinuousSummary extends Component {

--- a/frontend/src/components/IndividualModel/ContinuousTestOfInterest.js
+++ b/frontend/src/components/IndividualModel/ContinuousTestOfInterest.js
@@ -2,7 +2,8 @@ import HelpTextPopover from "components/common/HelpTextPopover";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
 import React, {Component} from "react";
-import {ff, fractionalFormatter} from "utils/formatters";
+
+import {ff, fractionalFormatter} from "@/utils/formatters";
 
 @observer
 class ContinuousTestOfInterest extends Component {

--- a/frontend/src/components/IndividualModel/ContinuousTestOfInterest.js
+++ b/frontend/src/components/IndividualModel/ContinuousTestOfInterest.js
@@ -1,9 +1,8 @@
-import React, {Component} from "react";
+import HelpTextPopover from "components/common/HelpTextPopover";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
-
+import React, {Component} from "react";
 import {ff, fractionalFormatter} from "utils/formatters";
-import HelpTextPopover from "components/common/HelpTextPopover";
 
 @observer
 class ContinuousTestOfInterest extends Component {

--- a/frontend/src/components/IndividualModel/DichotomousDeviance.js
+++ b/frontend/src/components/IndividualModel/DichotomousDeviance.js
@@ -1,7 +1,8 @@
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
 import React, {Component} from "react";
-import {ff, fractionalFormatter} from "utils/formatters";
+
+import {ff, fractionalFormatter} from "@/utils/formatters";
 
 @observer
 class DichotomousDeviance extends Component {

--- a/frontend/src/components/IndividualModel/DichotomousDeviance.js
+++ b/frontend/src/components/IndividualModel/DichotomousDeviance.js
@@ -1,7 +1,6 @@
-import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
-
+import React, {Component} from "react";
 import {ff, fractionalFormatter} from "utils/formatters";
 
 @observer

--- a/frontend/src/components/IndividualModel/DichotomousSummary.js
+++ b/frontend/src/components/IndividualModel/DichotomousSummary.js
@@ -1,7 +1,6 @@
-import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
-
+import React, {Component} from "react";
 import {ff, fourDecimalFormatter} from "utils/formatters";
 
 @observer

--- a/frontend/src/components/IndividualModel/DichotomousSummary.js
+++ b/frontend/src/components/IndividualModel/DichotomousSummary.js
@@ -1,7 +1,8 @@
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
 import React, {Component} from "react";
-import {ff, fourDecimalFormatter} from "utils/formatters";
+
+import {ff, fourDecimalFormatter} from "@/utils/formatters";
 
 @observer
 class DichotomousSummary extends Component {

--- a/frontend/src/components/IndividualModel/GoodnessFit.js
+++ b/frontend/src/components/IndividualModel/GoodnessFit.js
@@ -1,8 +1,8 @@
-import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
-
+import React, {Component} from "react";
 import {ff} from "utils/formatters";
+
 import {Dtype} from "../../constants/dataConstants";
 import {isLognormal} from "../../constants/modelConstants";
 

--- a/frontend/src/components/IndividualModel/GoodnessFit.js
+++ b/frontend/src/components/IndividualModel/GoodnessFit.js
@@ -1,7 +1,8 @@
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
 import React, {Component} from "react";
-import {ff} from "utils/formatters";
+
+import {ff} from "@/utils/formatters";
 
 import {Dtype} from "../../constants/dataConstants";
 import {isLognormal} from "../../constants/modelConstants";

--- a/frontend/src/components/IndividualModel/InfoTable.js
+++ b/frontend/src/components/IndividualModel/InfoTable.js
@@ -1,6 +1,6 @@
-import React, {Component} from "react";
 import {inject, observer} from "mobx-react";
 import PropTypes from "prop-types";
+import React, {Component} from "react";
 
 @inject("outputStore")
 @observer

--- a/frontend/src/components/IndividualModel/MaBenchmarkDose.js
+++ b/frontend/src/components/IndividualModel/MaBenchmarkDose.js
@@ -1,7 +1,6 @@
-import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
-
+import React, {Component} from "react";
 import {ff} from "utils/formatters";
 
 @observer

--- a/frontend/src/components/IndividualModel/MaBenchmarkDose.js
+++ b/frontend/src/components/IndividualModel/MaBenchmarkDose.js
@@ -1,7 +1,8 @@
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
 import React, {Component} from "react";
-import {ff} from "utils/formatters";
+
+import {ff} from "@/utils/formatters";
 
 @observer
 class MaBenchmarkDose extends Component {

--- a/frontend/src/components/IndividualModel/MaIndividualModels.js
+++ b/frontend/src/components/IndividualModel/MaIndividualModels.js
@@ -1,7 +1,6 @@
-import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
-
+import React, {Component} from "react";
 import {ff} from "utils/formatters";
 
 @observer

--- a/frontend/src/components/IndividualModel/MaIndividualModels.js
+++ b/frontend/src/components/IndividualModel/MaIndividualModels.js
@@ -1,7 +1,8 @@
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
 import React, {Component} from "react";
-import {ff} from "utils/formatters";
+
+import {ff} from "@/utils/formatters";
 
 @observer
 class MaIndividualModels extends Component {

--- a/frontend/src/components/IndividualModel/ModelDetailModal.js
+++ b/frontend/src/components/IndividualModel/ModelDetailModal.js
@@ -1,29 +1,27 @@
-import React, {Component} from "react";
-import {Modal, Row, Col} from "react-bootstrap";
 import {inject, observer} from "mobx-react";
 import PropTypes from "prop-types";
-
-import {MODEL_NESTED_DICHOTOMOUS} from "../../constants/mainConstants";
-
-import InfoTable from "./InfoTable";
-import ModelOptionsTable from "./ModelOptionsTable";
-import ParameterPriorTable from "./ParameterPriorTable";
-import ModelParameters from "./ModelParameters";
-import GoodnessFit from "./GoodnessFit";
-import CDFTable from "./CDFTable";
-import CDFPlot from "./CDFPlot";
-import DoseResponsePlot from "../common/DoseResponsePlot";
-import ContinuousTestOfInterest from "./ContinuousTestOfInterest";
-import DichotomousSummary from "./DichotomousSummary";
-import DichotomousDeviance from "./DichotomousDeviance";
-import ContinuousSummary from "./ContinuousSummary";
-import ContinuousDeviance from "./ContinuousDeviance";
-import MaBenchmarkDose from "./MaBenchmarkDose";
-import MaIndividualModels from "./MaIndividualModels";
-import NestedDichotomousModalBody from "../Output/NestedDichotomous/ModalBody";
+import React, {Component} from "react";
+import {Col, Modal, Row} from "react-bootstrap";
 
 import * as dc from "../../constants/dataConstants";
+import {MODEL_NESTED_DICHOTOMOUS} from "../../constants/mainConstants";
 import Button from "../common/Button";
+import DoseResponsePlot from "../common/DoseResponsePlot";
+import NestedDichotomousModalBody from "../Output/NestedDichotomous/ModalBody";
+import CDFPlot from "./CDFPlot";
+import CDFTable from "./CDFTable";
+import ContinuousDeviance from "./ContinuousDeviance";
+import ContinuousSummary from "./ContinuousSummary";
+import ContinuousTestOfInterest from "./ContinuousTestOfInterest";
+import DichotomousDeviance from "./DichotomousDeviance";
+import DichotomousSummary from "./DichotomousSummary";
+import GoodnessFit from "./GoodnessFit";
+import InfoTable from "./InfoTable";
+import MaBenchmarkDose from "./MaBenchmarkDose";
+import MaIndividualModels from "./MaIndividualModels";
+import ModelOptionsTable from "./ModelOptionsTable";
+import ModelParameters from "./ModelParameters";
+import ParameterPriorTable from "./ParameterPriorTable";
 
 @observer
 class ModelBody extends Component {

--- a/frontend/src/components/IndividualModel/ModelOptionsTable.js
+++ b/frontend/src/components/IndividualModel/ModelOptionsTable.js
@@ -1,16 +1,17 @@
-import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
-import {priorClassLabels} from "../../constants/outputConstants";
+import React, {Component} from "react";
+import {ff} from "utils/formatters";
+
+import {getLabel} from "../../common";
 import {Dtype} from "../../constants/dataConstants";
 import {hasDegrees} from "../../constants/modelConstants";
 import {
-    dichotomousBmrOptions,
     continuousBmrOptions,
+    dichotomousBmrOptions,
     distTypeOptions,
 } from "../../constants/optionsConstants";
-import {getLabel} from "../../common";
-import {ff} from "utils/formatters";
+import {priorClassLabels} from "../../constants/outputConstants";
 
 const restrictionMapping = {
     0: ["Model Restriction", "Unrestricted"],

--- a/frontend/src/components/IndividualModel/ModelOptionsTable.js
+++ b/frontend/src/components/IndividualModel/ModelOptionsTable.js
@@ -1,7 +1,8 @@
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
 import React, {Component} from "react";
-import {ff} from "utils/formatters";
+
+import {ff} from "@/utils/formatters";
 
 import {getLabel} from "../../common";
 import {Dtype} from "../../constants/dataConstants";

--- a/frontend/src/components/IndividualModel/ModelParameters.js
+++ b/frontend/src/components/IndividualModel/ModelParameters.js
@@ -1,10 +1,10 @@
+import HelpTextPopover from "components/common/HelpTextPopover";
 import _ from "lodash";
-import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
+import React, {Component} from "react";
 
 import {parameterFormatter} from "../../utils/formatters";
-import HelpTextPopover from "components/common/HelpTextPopover";
 
 @observer
 class ModelParameters extends Component {

--- a/frontend/src/components/IndividualModel/ParameterPriorTable.js
+++ b/frontend/src/components/IndividualModel/ParameterPriorTable.js
@@ -2,7 +2,8 @@ import _ from "lodash";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
 import React, {Component} from "react";
-import {ff} from "utils/formatters";
+
+import {ff} from "@/utils/formatters";
 
 import {getLabel} from "../../common";
 import {isFrequentist, priorTypeLabels} from "../../constants/outputConstants";

--- a/frontend/src/components/IndividualModel/ParameterPriorTable.js
+++ b/frontend/src/components/IndividualModel/ParameterPriorTable.js
@@ -1,11 +1,11 @@
 import _ from "lodash";
-import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
-
-import {isFrequentist, priorTypeLabels} from "../../constants/outputConstants";
-import {getLabel} from "../../common";
+import React, {Component} from "react";
 import {ff} from "utils/formatters";
+
+import {getLabel} from "../../common";
+import {isFrequentist, priorTypeLabels} from "../../constants/outputConstants";
 
 const renderPriorRow = prior => {
         return (

--- a/frontend/src/components/Logic/DecisionLogic.js
+++ b/frontend/src/components/Logic/DecisionLogic.js
@@ -1,10 +1,11 @@
-import React, {Component} from "react";
 import {inject, observer} from "mobx-react";
 import PropTypes from "prop-types";
+import React, {Component} from "react";
+
 import {checkOrEmpty} from "../../common";
+import Button from "../common/Button";
 import CheckboxInput from "../common/CheckboxInput";
 import FloatInput from "../common/FloatInput";
-import Button from "../common/Button";
 
 @inject("logicStore")
 @observer

--- a/frontend/src/components/Logic/LogicRoot.js
+++ b/frontend/src/components/Logic/LogicRoot.js
@@ -1,7 +1,7 @@
 import _ from "lodash";
-import React, {Component} from "react";
-import PropTypes from "prop-types";
 import {inject, observer} from "mobx-react";
+import PropTypes from "prop-types";
+import React, {Component} from "react";
 
 import DecisionLogic from "./DecisionLogic";
 import RuleTable from "./RuleTable";

--- a/frontend/src/components/Logic/RuleRow.js
+++ b/frontend/src/components/Logic/RuleRow.js
@@ -1,10 +1,10 @@
 import _ from "lodash";
-import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
+import React, {Component} from "react";
 
 import {checkOrEmpty} from "../../common";
-import {BIN_NAMES, ruleLookups, logicBinOptions} from "../../constants/logicConstants";
+import {BIN_NAMES, logicBinOptions, ruleLookups} from "../../constants/logicConstants";
 import {MODEL_CONTINUOUS, MODEL_DICHOTOMOUS} from "../../constants/mainConstants";
 import CheckboxInput from "../common/CheckboxInput";
 import FloatInput from "../common/FloatInput";

--- a/frontend/src/components/Logic/RuleTable.js
+++ b/frontend/src/components/Logic/RuleTable.js
@@ -1,10 +1,10 @@
 import _ from "lodash";
-import React, {Component} from "react";
 import {inject, observer} from "mobx-react";
 import PropTypes from "prop-types";
+import React, {Component} from "react";
 
-import RuleRow from "./RuleRow";
 import {ruleOrder} from "../../constants/logicConstants";
+import RuleRow from "./RuleRow";
 
 @inject("logicStore")
 @observer

--- a/frontend/src/components/Main/Actions/Actions.js
+++ b/frontend/src/components/Main/Actions/Actions.js
@@ -1,7 +1,8 @@
 import _ from "lodash";
-import React, {Component} from "react";
 import {inject, observer} from "mobx-react";
 import PropTypes from "prop-types";
+import React, {Component} from "react";
+
 import Button from "../../common/Button";
 
 const getDeletionDateText = function(editSettings) {

--- a/frontend/src/components/Main/Actions/ShareActions.js
+++ b/frontend/src/components/Main/Actions/ShareActions.js
@@ -1,9 +1,9 @@
-import React, {Component} from "react";
 import {inject, observer} from "mobx-react";
 import PropTypes from "prop-types";
+import React, {Component} from "react";
 
-import ClipboardButton from "../../common/ClipboardButton";
 import Button from "../../common/Button";
+import ClipboardButton from "../../common/ClipboardButton";
 
 @inject("mainStore")
 @observer

--- a/frontend/src/components/Main/Actions/StatusToast.js
+++ b/frontend/src/components/Main/Actions/StatusToast.js
@@ -1,7 +1,7 @@
-import React, {Component} from "react";
 import {inject, observer} from "mobx-react";
-import {Toast} from "react-bootstrap";
 import PropTypes from "prop-types";
+import React, {Component} from "react";
+import {Toast} from "react-bootstrap";
 
 @inject("mainStore")
 @observer

--- a/frontend/src/components/Main/Actions/WordReportOptionsModal.js
+++ b/frontend/src/components/Main/Actions/WordReportOptionsModal.js
@@ -1,10 +1,10 @@
-import React, {Component} from "react";
+import LabelInput from "components/common/LabelInput";
 import {inject, observer} from "mobx-react";
-import {Modal} from "react-bootstrap";
 import PropTypes from "prop-types";
+import React, {Component} from "react";
+import {Modal} from "react-bootstrap";
 
 import Button from "../../common/Button";
-import LabelInput from "components/common/LabelInput";
 import CheckboxInput from "../../common/CheckboxInput";
 
 @inject("mainStore")

--- a/frontend/src/components/Main/AnalysisForm/AnalysisForm.js
+++ b/frontend/src/components/Main/AnalysisForm/AnalysisForm.js
@@ -1,13 +1,13 @@
-import React, {Component} from "react";
 import {inject, observer} from "mobx-react";
 import PropTypes from "prop-types";
+import React, {Component} from "react";
 
 import * as mc from "../../../constants/mainConstants";
-import Spinner from "../../common/Spinner";
-import SelectInput from "../../common/SelectInput";
-import TextInput from "../../common/TextInput";
-import TextAreaInput from "../../common/TextAreaInput";
 import Button from "../../common/Button";
+import SelectInput from "../../common/SelectInput";
+import Spinner from "../../common/Spinner";
+import TextAreaInput from "../../common/TextAreaInput";
+import TextInput from "../../common/TextInput";
 
 @observer
 class RunChecklist extends Component {

--- a/frontend/src/components/Main/AnalysisForm/AnalysisFormReadOnly.js
+++ b/frontend/src/components/Main/AnalysisForm/AnalysisFormReadOnly.js
@@ -1,6 +1,6 @@
-import React, {Component} from "react";
 import {inject, observer} from "mobx-react";
 import PropTypes from "prop-types";
+import React, {Component} from "react";
 
 @inject("mainStore")
 @observer

--- a/frontend/src/components/Main/DatasetModelOptionList/DatasetModelOption.js
+++ b/frontend/src/components/Main/DatasetModelOptionList/DatasetModelOption.js
@@ -1,13 +1,13 @@
-import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
+import React, {Component} from "react";
 
+import {checkOrEmpty, getLabel} from "../../../common";
 import {
     adverseDirectionOptions,
-    getDegreeOptions,
     allDegreeOptions,
+    getDegreeOptions,
 } from "../../../constants/dataConstants";
-import {getLabel, checkOrEmpty} from "../../../common";
 import CheckboxInput from "../../common/CheckboxInput";
 import SelectInput from "../../common/SelectInput";
 

--- a/frontend/src/components/Main/DatasetModelOptionList/DatasetModelOptionList.js
+++ b/frontend/src/components/Main/DatasetModelOptionList/DatasetModelOptionList.js
@@ -1,10 +1,10 @@
-import React, {Component} from "react";
 import {inject, observer} from "mobx-react";
-import DatasetModelOption from "./DatasetModelOption";
 import PropTypes from "prop-types";
+import React, {Component} from "react";
 
 import {Dtype} from "../../../constants/dataConstants";
 import HelpTextPopover from "../../common/HelpTextPopover";
+import DatasetModelOption from "./DatasetModelOption";
 
 const maxDegreeText = `Studies have indicated that higher degree polynomial models are not
     warranted in that they generally do not sufficiently improve fit over simpler models

--- a/frontend/src/components/Main/Main.js
+++ b/frontend/src/components/Main/Main.js
@@ -1,14 +1,13 @@
+import {inject, observer} from "mobx-react";
 import PropTypes from "prop-types";
 import React, {Component} from "react";
 
+import Button from "../common/Button";
 import AnalysisForm from "./AnalysisForm/AnalysisForm";
+import AnalysisFormReadOnly from "./AnalysisForm/AnalysisFormReadOnly";
+import DatasetModelOptionList from "./DatasetModelOptionList/DatasetModelOptionList";
 import ModelsCheckBoxList from "./ModelsForm/ModelsCheckBoxList";
 import OptionsFormList from "./OptionsForm/OptionsFormList";
-
-import {inject, observer} from "mobx-react";
-import DatasetModelOptionList from "./DatasetModelOptionList/DatasetModelOptionList";
-import AnalysisFormReadOnly from "./AnalysisForm/AnalysisFormReadOnly";
-import Button from "../common/Button";
 
 @inject("mainStore")
 @observer

--- a/frontend/src/components/Main/ModelsForm/ModelsCheckBox.js
+++ b/frontend/src/components/Main/ModelsForm/ModelsCheckBox.js
@@ -1,12 +1,12 @@
-import React from "react";
-import PropTypes from "prop-types";
 import {observer} from "mobx-react";
+import PropTypes from "prop-types";
+import React from "react";
 
-import * as mc from "../../../constants/mainConstants";
 import {checkOrEmpty} from "../../../common";
-import HelpTextPopover from "../../common/HelpTextPopover";
+import * as mc from "../../../constants/mainConstants";
 import CheckboxInput from "../../common/CheckboxInput";
 import FloatInput from "../../common/FloatInput";
+import HelpTextPopover from "../../common/HelpTextPopover";
 
 const isModelChecked = function(models, type, model) {
         let checked = false;

--- a/frontend/src/components/Main/ModelsForm/ModelsCheckBoxHeader.js
+++ b/frontend/src/components/Main/ModelsForm/ModelsCheckBoxHeader.js
@@ -1,11 +1,11 @@
-import React from "react";
-import PropTypes from "prop-types";
 import {observer} from "mobx-react";
+import PropTypes from "prop-types";
+import React from "react";
 
-import {allModelOptions} from "../../../constants/modelConstants";
 import * as mc from "../../../constants/mainConstants";
-import HelpTextPopover from "../../common/HelpTextPopover";
+import {allModelOptions} from "../../../constants/modelConstants";
 import CheckboxInput from "../../common/CheckboxInput";
+import HelpTextPopover from "../../common/HelpTextPopover";
 
 const areAllModelsChecked = function(modelType, type, models) {
         return type in models && models[type].length === allModelOptions[modelType][type].length;

--- a/frontend/src/components/Main/ModelsForm/ModelsCheckBoxList.js
+++ b/frontend/src/components/Main/ModelsForm/ModelsCheckBoxList.js
@@ -1,9 +1,9 @@
+import {inject, observer} from "mobx-react";
+import PropTypes from "prop-types";
 import React, {Component} from "react";
 
-import {inject, observer} from "mobx-react";
 import ModelsCheckBox from "./ModelsCheckBox";
 import ModelsCheckBoxHeader from "./ModelsCheckBoxHeader";
-import PropTypes from "prop-types";
 
 @inject("modelsStore")
 @observer

--- a/frontend/src/components/Main/OptionsForm/OptionsForm.js
+++ b/frontend/src/components/Main/OptionsForm/OptionsForm.js
@@ -1,18 +1,18 @@
-import React from "react";
 import PropTypes from "prop-types";
+import React from "react";
 
 import * as mc from "../../../constants/mainConstants";
-import SelectInput from "../../common/SelectInput";
 import {
-    dichotomousBmrOptions,
+    backgroundOptions,
     continuousBmrOptions,
+    dichotomousBmrOptions,
     distTypeOptions,
     litterSpecificCovariateOptions,
-    backgroundOptions,
 } from "../../../constants/optionsConstants";
-import IntegerInput from "../../common/IntegerInput";
-import FloatInput from "../../common/FloatInput";
 import Button from "../../common/Button";
+import FloatInput from "../../common/FloatInput";
+import IntegerInput from "../../common/IntegerInput";
+import SelectInput from "../../common/SelectInput";
 
 const OptionsForm = props => {
     return (

--- a/frontend/src/components/Main/OptionsForm/OptionsFormList.js
+++ b/frontend/src/components/Main/OptionsForm/OptionsFormList.js
@@ -1,11 +1,8 @@
-import React, {Component} from "react";
+import {toJS} from "mobx";
 import {inject, observer} from "mobx-react";
 import PropTypes from "prop-types";
-import {toJS} from "mobx";
+import React, {Component} from "react";
 
-import OptionsForm from "./OptionsForm";
-import OptionsReadOnly from "./OptionsReadOnly";
-import HelpTextPopover from "../../common/HelpTextPopover";
 import {
     MODEL_CONTINUOUS,
     MODEL_DICHOTOMOUS,
@@ -13,6 +10,9 @@ import {
     MODEL_NESTED_DICHOTOMOUS,
 } from "../../../constants/mainConstants";
 import Button from "../../common/Button";
+import HelpTextPopover from "../../common/HelpTextPopover";
+import OptionsForm from "./OptionsForm";
+import OptionsReadOnly from "./OptionsReadOnly";
 
 @inject("optionsStore")
 @observer

--- a/frontend/src/components/Main/OptionsForm/OptionsReadOnly.js
+++ b/frontend/src/components/Main/OptionsForm/OptionsReadOnly.js
@@ -1,6 +1,7 @@
 import PropTypes from "prop-types";
 import React from "react";
-import {ff} from "utils/formatters";
+
+import {ff} from "@/utils/formatters";
 
 import {getLabel} from "../../../common";
 import {MODEL_CONTINUOUS, MODEL_DICHOTOMOUS} from "../../../constants/mainConstants";

--- a/frontend/src/components/Main/OptionsForm/OptionsReadOnly.js
+++ b/frontend/src/components/Main/OptionsForm/OptionsReadOnly.js
@@ -1,14 +1,14 @@
-import React from "react";
 import PropTypes from "prop-types";
+import React from "react";
+import {ff} from "utils/formatters";
 
+import {getLabel} from "../../../common";
 import {MODEL_CONTINUOUS, MODEL_DICHOTOMOUS} from "../../../constants/mainConstants";
 import {
-    dichotomousBmrOptions,
     continuousBmrOptions,
+    dichotomousBmrOptions,
     distTypeOptions,
 } from "../../../constants/optionsConstants";
-import {getLabel} from "../../../common";
-import {ff} from "utils/formatters";
 
 const OptionsReadOnly = props => {
     const {options, modelType, idx} = props;

--- a/frontend/src/components/Navigation.js
+++ b/frontend/src/components/Navigation.js
@@ -1,16 +1,16 @@
-import React, {Component} from "react";
-import {Redirect, Route, NavLink} from "react-router-dom";
 import {inject, observer} from "mobx-react";
-import Main from "./Main/Main";
+import PropTypes from "prop-types";
+import React, {Component} from "react";
+import {NavLink, Redirect, Route} from "react-router-dom";
+
 import DataTab from "./Data/DataTab";
 import LogicRoot from "./Logic/LogicRoot";
-import Output from "./Output/Output";
-import PropTypes from "prop-types";
-
 import Actions from "./Main/Actions/Actions";
 import ShareActions from "./Main/Actions/ShareActions";
 import StatusToast from "./Main/Actions/StatusToast";
 import WordReportOptionsModal from "./Main/Actions/WordReportOptionsModal";
+import Main from "./Main/Main";
+import Output from "./Output/Output";
 
 @inject("mainStore")
 @observer

--- a/frontend/src/components/Output/BayesianResultTable.js
+++ b/frontend/src/components/Output/BayesianResultTable.js
@@ -2,7 +2,8 @@ import _ from "lodash";
 import {inject, observer} from "mobx-react";
 import PropTypes from "prop-types";
 import React, {Component} from "react";
-import {ff, fractionalFormatter} from "utils/formatters";
+
+import {ff, fractionalFormatter} from "@/utils/formatters";
 
 import {maIndex, modelClasses} from "../../constants/outputConstants";
 

--- a/frontend/src/components/Output/BayesianResultTable.js
+++ b/frontend/src/components/Output/BayesianResultTable.js
@@ -1,10 +1,10 @@
 import _ from "lodash";
 import {inject, observer} from "mobx-react";
-import React, {Component} from "react";
 import PropTypes from "prop-types";
+import React, {Component} from "react";
+import {ff, fractionalFormatter} from "utils/formatters";
 
 import {maIndex, modelClasses} from "../../constants/outputConstants";
-import {ff, fractionalFormatter} from "utils/formatters";
 
 @inject("outputStore")
 @observer

--- a/frontend/src/components/Output/FrequentistResultTable.js
+++ b/frontend/src/components/Output/FrequentistResultTable.js
@@ -3,8 +3,9 @@ import {toJS} from "mobx";
 import {inject, observer} from "mobx-react";
 import PropTypes from "prop-types";
 import React, {Component} from "react";
-import {fractionalFormatter} from "utils/formatters";
-import {ff} from "utils/formatters";
+
+import {fractionalFormatter} from "@/utils/formatters";
+import {ff} from "@/utils/formatters";
 
 import {BIN_LABELS} from "../../constants/logicConstants";
 import {MODEL_MULTI_TUMOR} from "../../constants/mainConstants";

--- a/frontend/src/components/Output/FrequentistResultTable.js
+++ b/frontend/src/components/Output/FrequentistResultTable.js
@@ -1,16 +1,15 @@
 import _ from "lodash";
 import {toJS} from "mobx";
 import {inject, observer} from "mobx-react";
-import React, {Component} from "react";
 import PropTypes from "prop-types";
-
+import React, {Component} from "react";
 import {fractionalFormatter} from "utils/formatters";
-import {MODEL_MULTI_TUMOR} from "../../constants/mainConstants";
-import {BIN_LABELS} from "../../constants/logicConstants";
-import {getPValue, modelClasses, priorClass} from "../../constants/outputConstants";
 import {ff} from "utils/formatters";
-import Button from "../common/Button";
 
+import {BIN_LABELS} from "../../constants/logicConstants";
+import {MODEL_MULTI_TUMOR} from "../../constants/mainConstants";
+import {getPValue, modelClasses, priorClass} from "../../constants/outputConstants";
+import Button from "../common/Button";
 import Popover from "../common/Popover";
 
 const getModelBinLabel = function(output, index) {

--- a/frontend/src/components/Output/NestedDichotomous/BootstrapResults.js
+++ b/frontend/src/components/Output/NestedDichotomous/BootstrapResults.js
@@ -1,6 +1,6 @@
-import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
+import React, {Component} from "react";
 
 @observer
 class BootstrapResult extends Component {

--- a/frontend/src/components/Output/NestedDichotomous/BootstrapRuns.js
+++ b/frontend/src/components/Output/NestedDichotomous/BootstrapRuns.js
@@ -1,6 +1,6 @@
-import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
+import React, {Component} from "react";
 
 @observer
 class BootstrapRuns extends Component {

--- a/frontend/src/components/Output/NestedDichotomous/LitterData.js
+++ b/frontend/src/components/Output/NestedDichotomous/LitterData.js
@@ -1,7 +1,7 @@
 import _ from "lodash";
-import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
+import React, {Component} from "react";
 
 @observer
 class LitterData extends Component {

--- a/frontend/src/components/Output/NestedDichotomous/ModalBody.js
+++ b/frontend/src/components/Output/NestedDichotomous/ModalBody.js
@@ -1,12 +1,12 @@
-import React, {Component} from "react";
-import {Modal, Row, Col} from "react-bootstrap";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
+import React, {Component} from "react";
+import {Col, Modal, Row} from "react-bootstrap";
 
 import BootstrapResults from "./BootstrapResults";
 import BootstrapRuns from "./BootstrapRuns";
-import ScaledResidual from "./ScaledResidual";
 import LitterData from "./LitterData";
+import ScaledResidual from "./ScaledResidual";
 
 @observer
 class ModalBody extends Component {

--- a/frontend/src/components/Output/NestedDichotomous/ResultTable.js
+++ b/frontend/src/components/Output/NestedDichotomous/ResultTable.js
@@ -2,7 +2,8 @@ import _ from "lodash";
 import {inject, observer} from "mobx-react";
 import PropTypes from "prop-types";
 import React, {Component} from "react";
-import {ff} from "utils/formatters";
+
+import {ff} from "@/utils/formatters";
 
 import {modelClasses} from "../../../constants/outputConstants";
 

--- a/frontend/src/components/Output/NestedDichotomous/ResultTable.js
+++ b/frontend/src/components/Output/NestedDichotomous/ResultTable.js
@@ -1,10 +1,10 @@
 import _ from "lodash";
 import {inject, observer} from "mobx-react";
-import React, {Component} from "react";
 import PropTypes from "prop-types";
+import React, {Component} from "react";
+import {ff} from "utils/formatters";
 
 import {modelClasses} from "../../../constants/outputConstants";
-import {ff} from "utils/formatters";
 
 @inject("outputStore")
 @observer

--- a/frontend/src/components/Output/NestedDichotomous/ScaledResidual.js
+++ b/frontend/src/components/Output/NestedDichotomous/ScaledResidual.js
@@ -1,6 +1,6 @@
-import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
+import React, {Component} from "react";
 
 @observer
 class ScaledResidual extends Component {

--- a/frontend/src/components/Output/OptionSetTable.js
+++ b/frontend/src/components/Output/OptionSetTable.js
@@ -9,7 +9,8 @@ import {
 import {inject, observer} from "mobx-react";
 import PropTypes from "prop-types";
 import React, {Component} from "react";
-import {ff} from "utils/formatters";
+
+import {ff} from "@/utils/formatters";
 
 @inject("outputStore")
 @observer

--- a/frontend/src/components/Output/OptionSetTable.js
+++ b/frontend/src/components/Output/OptionSetTable.js
@@ -1,16 +1,15 @@
-import {inject, observer} from "mobx-react";
-import React, {Component} from "react";
-import PropTypes from "prop-types";
-
-import {MODEL_CONTINUOUS, MODEL_DICHOTOMOUS} from "constants/mainConstants";
+import {getLabel} from "common";
 import {adverseDirectionOptions, allDegreeOptions} from "constants/dataConstants";
+import {MODEL_CONTINUOUS, MODEL_DICHOTOMOUS} from "constants/mainConstants";
 import {
-    dichotomousBmrOptions,
     continuousBmrOptions,
+    dichotomousBmrOptions,
     distTypeOptions,
 } from "constants/optionsConstants";
+import {inject, observer} from "mobx-react";
+import PropTypes from "prop-types";
+import React, {Component} from "react";
 import {ff} from "utils/formatters";
-import {getLabel} from "common";
 
 @inject("outputStore")
 @observer

--- a/frontend/src/components/Output/Output.js
+++ b/frontend/src/components/Output/Output.js
@@ -1,20 +1,19 @@
-import React, {Component} from "react";
-import {inject, observer} from "mobx-react";
-import PropTypes from "prop-types";
-
-import {MODEL_NESTED_DICHOTOMOUS} from "../../constants/mainConstants";
-
-import ModelDetailModal from "../IndividualModel/ModelDetailModal";
-import FrequentistResultTable from "./FrequentistResultTable";
-import NestedDichotomousResultTable from "./NestedDichotomous/ResultTable";
-import BayesianResultTable from "./BayesianResultTable";
-import DatasetTable from "../Data/DatasetTable";
-import OptionSetTable from "./OptionSetTable";
-import SelectModel from "./SelectModel";
-import DoseResponsePlot from "../common/DoseResponsePlot";
 import "./Output.css";
 
+import {inject, observer} from "mobx-react";
+import PropTypes from "prop-types";
+import React, {Component} from "react";
+
+import {MODEL_NESTED_DICHOTOMOUS} from "../../constants/mainConstants";
+import DoseResponsePlot from "../common/DoseResponsePlot";
 import SelectInput from "../common/SelectInput";
+import DatasetTable from "../Data/DatasetTable";
+import ModelDetailModal from "../IndividualModel/ModelDetailModal";
+import BayesianResultTable from "./BayesianResultTable";
+import FrequentistResultTable from "./FrequentistResultTable";
+import NestedDichotomousResultTable from "./NestedDichotomous/ResultTable";
+import OptionSetTable from "./OptionSetTable";
+import SelectModel from "./SelectModel";
 
 const OutputErrorComponent = ({title, children}) => {
     return (

--- a/frontend/src/components/Output/SelectModel.js
+++ b/frontend/src/components/Output/SelectModel.js
@@ -1,11 +1,11 @@
 import _ from "lodash";
-import React, {Component} from "react";
 import {inject, observer} from "mobx-react";
 import PropTypes from "prop-types";
+import React, {Component} from "react";
 
+import Button from "../common/Button";
 import SelectInput from "../common/SelectInput";
 import TextAreaInput from "../common/TextAreaInput";
-import Button from "../common/Button";
 
 @inject("outputStore")
 @observer

--- a/frontend/src/components/common/Button.js
+++ b/frontend/src/components/common/Button.js
@@ -1,6 +1,6 @@
-import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
+import React, {Component} from "react";
 
 @observer
 class Button extends Component {

--- a/frontend/src/components/common/CheckboxInput.js
+++ b/frontend/src/components/common/CheckboxInput.js
@@ -1,6 +1,6 @@
-import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
+import React, {Component} from "react";
 
 import {randomString} from "../../common";
 

--- a/frontend/src/components/common/ClipboardButton.js
+++ b/frontend/src/components/common/ClipboardButton.js
@@ -1,6 +1,6 @@
 import Clipboard from "clipboard";
-import React, {Component} from "react";
 import PropTypes from "prop-types";
+import React, {Component} from "react";
 
 class ClipboardButton extends Component {
     // copy text to clipboard

--- a/frontend/src/components/common/DoseResponsePlot.js
+++ b/frontend/src/components/common/DoseResponsePlot.js
@@ -1,8 +1,8 @@
-import React, {Component} from "react";
-import {observer} from "mobx-react";
-import Plot from "react-plotly.js";
-import PropTypes from "prop-types";
 import {toJS} from "mobx";
+import {observer} from "mobx-react";
+import PropTypes from "prop-types";
+import React, {Component} from "react";
+import Plot from "react-plotly.js";
 
 import {getConfig} from "../../constants/plotting";
 

--- a/frontend/src/components/common/ErrorMessage.js
+++ b/frontend/src/components/common/ErrorMessage.js
@@ -1,5 +1,5 @@
-import React from "react";
 import PropTypes from "prop-types";
+import React from "react";
 
 const ErrorMessage = ({error}) => {
     if (!error) {

--- a/frontend/src/components/common/FloatInput.js
+++ b/frontend/src/components/common/FloatInput.js
@@ -1,6 +1,6 @@
-import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
+import React, {Component} from "react";
 
 import {randomString} from "../../common";
 import LabelInput from "./LabelInput";

--- a/frontend/src/components/common/HelpTextPopover.js
+++ b/frontend/src/components/common/HelpTextPopover.js
@@ -1,5 +1,5 @@
-import React, {Component} from "react";
 import PropTypes from "prop-types";
+import React, {Component} from "react";
 
 import Popover from "./Popover";
 

--- a/frontend/src/components/common/IntegerInput.js
+++ b/frontend/src/components/common/IntegerInput.js
@@ -1,7 +1,7 @@
 import _ from "lodash";
-import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
+import React, {Component} from "react";
 
 import {randomString} from "../../common";
 import LabelInput from "./LabelInput";

--- a/frontend/src/components/common/LabelInput.js
+++ b/frontend/src/components/common/LabelInput.js
@@ -1,5 +1,5 @@
-import React, {Component} from "react";
 import PropTypes from "prop-types";
+import React, {Component} from "react";
 
 class LabelInput extends Component {
     render() {

--- a/frontend/src/components/common/Popover.js
+++ b/frontend/src/components/common/Popover.js
@@ -1,7 +1,8 @@
 import _ from "lodash";
-import $ from "$";
-import React, {Component} from "react";
 import PropTypes from "prop-types";
+import React, {Component} from "react";
+
+import $ from "$";
 
 class Popover extends Component {
     constructor(props) {

--- a/frontend/src/components/common/SelectInput.js
+++ b/frontend/src/components/common/SelectInput.js
@@ -1,6 +1,6 @@
-import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
+import React, {Component} from "react";
 
 import {randomString} from "../../common";
 import LabelInput from "./LabelInput";

--- a/frontend/src/components/common/Spinner.js
+++ b/frontend/src/components/common/Spinner.js
@@ -1,5 +1,5 @@
-import React from "react";
 import PropTypes from "prop-types";
+import React from "react";
 
 class Spinner extends React.Component {
     render() {

--- a/frontend/src/components/common/TextAreaInput.js
+++ b/frontend/src/components/common/TextAreaInput.js
@@ -1,6 +1,6 @@
-import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
+import React, {Component} from "react";
 
 import {randomString} from "../../common";
 import LabelInput from "./LabelInput";

--- a/frontend/src/components/common/TextInput.js
+++ b/frontend/src/components/common/TextInput.js
@@ -1,6 +1,6 @@
-import React, {Component} from "react";
 import {observer} from "mobx-react";
 import PropTypes from "prop-types";
+import React, {Component} from "react";
 
 import {randomString} from "../../common";
 import LabelInput from "./LabelInput";

--- a/frontend/src/constants/dataConstants.js
+++ b/frontend/src/constants/dataConstants.js
@@ -1,4 +1,5 @@
 import _ from "lodash";
+
 import * as mc from "./mainConstants";
 
 const Dtype = {

--- a/frontend/src/constants/modelConstants.js
+++ b/frontend/src/constants/modelConstants.js
@@ -1,8 +1,8 @@
 import {
     MODEL_CONTINUOUS,
     MODEL_DICHOTOMOUS,
-    MODEL_NESTED_DICHOTOMOUS,
     MODEL_MULTI_TUMOR,
+    MODEL_NESTED_DICHOTOMOUS,
 } from "./mainConstants";
 
 const modelsList = {
@@ -77,4 +77,4 @@ const modelsList = {
     },
     hasDegrees = new Set(["Multistage", "Polynomial"]);
 
-export {allModelOptions, modelsList, models, hasDegrees, isLognormal};
+export {allModelOptions, hasDegrees, isLognormal, models, modelsList};

--- a/frontend/src/constants/plotting.js
+++ b/frontend/src/constants/plotting.js
@@ -1,7 +1,8 @@
 import _ from "lodash";
-import {Dtype} from "./dataConstants";
+
 import {continuousErrorBars, dichotomousErrorBars} from "../utils/errorBars";
 import {ff} from "../utils/formatters";
+import {Dtype} from "./dataConstants";
 
 const doseResponseLayout = {
         autosize: true,

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,10 +1,10 @@
+import {Provider} from "mobx-react";
 import React from "react";
 import ReactDOM from "react-dom";
-import {Provider} from "mobx-react";
 
 import App from "./App";
-import history from "./utils/localHistory";
 import rootStore from "./stores/RootStore";
+import history from "./utils/localHistory";
 
 const Root = (
     <Provider

--- a/frontend/src/stores/DataStore.js
+++ b/frontend/src/stores/DataStore.js
@@ -1,14 +1,14 @@
-import {observable, action, computed, toJS} from "mobx";
 import _ from "lodash";
+import {action, computed, observable, toJS} from "mobx";
 
 import * as dc from "../constants/dataConstants";
-import {getDrLayout, getDrDatasetPlotData} from "../constants/plotting";
 import {
+    columns,
     datasetTypesByModelType,
     getDefaultDataset,
     getExampleData,
-    columns,
 } from "../constants/dataConstants";
+import {getDrDatasetPlotData, getDrLayout} from "../constants/plotting";
 
 let validateTabularData = function(text, columns) {
     let data = [],

--- a/frontend/src/stores/DatasetModelOptionStore.js
+++ b/frontend/src/stores/DatasetModelOptionStore.js
@@ -1,5 +1,5 @@
 import _ from "lodash";
-import {computed, observable, action} from "mobx";
+import {action, computed, observable} from "mobx";
 
 import {datasetOptions, getDefaultDegree} from "../constants/dataConstants";
 

--- a/frontend/src/stores/LogicStore.js
+++ b/frontend/src/stores/LogicStore.js
@@ -1,4 +1,4 @@
-import {observable, action, computed} from "mobx";
+import {action, computed, observable} from "mobx";
 
 class LogicStore {
     @observable logic = null;

--- a/frontend/src/stores/MainStore.js
+++ b/frontend/src/stores/MainStore.js
@@ -1,10 +1,10 @@
 import {saveAs} from "file-saver";
-import slugify from "slugify";
-import {observable, action, computed, toJS} from "mobx";
 import _ from "lodash";
+import {action, computed, observable, toJS} from "mobx";
+import slugify from "slugify";
 
+import {getHeaders, simulateClick} from "../common";
 import * as mc from "../constants/mainConstants";
-import {simulateClick, getHeaders} from "../common";
 
 class MainStore {
     constructor(rootStore) {

--- a/frontend/src/stores/ModelsStore.js
+++ b/frontend/src/stores/ModelsStore.js
@@ -1,9 +1,8 @@
 import _ from "lodash";
-import {observable, action, computed} from "mobx";
-
-import {allModelOptions, models} from "../constants/modelConstants";
+import {action, computed, observable} from "mobx";
 
 import * as mc from "../constants/mainConstants";
+import {allModelOptions, models} from "../constants/modelConstants";
 
 class ModelsStore {
     constructor(rootStore) {

--- a/frontend/src/stores/OptionsStore.js
+++ b/frontend/src/stores/OptionsStore.js
@@ -1,7 +1,8 @@
-import {observable, action, computed} from "mobx";
 import _ from "lodash";
-import * as constant from "../constants/optionsConstants";
+import {action, computed, observable} from "mobx";
+
 import {MODEL_CONTINUOUS} from "../constants/mainConstants";
+import * as constant from "../constants/optionsConstants";
 
 class OptionsStore {
     constructor(rootStore) {

--- a/frontend/src/stores/OutputStore.js
+++ b/frontend/src/stores/OutputStore.js
@@ -1,19 +1,19 @@
-import {observable, action, computed, toJS} from "mobx";
 import _ from "lodash";
-import {getHeaders} from "../common";
+import {action, computed, observable, toJS} from "mobx";
 
-import {modelClasses, maIndex} from "../constants/outputConstants";
+import {getHeaders} from "../common";
+import {maIndex, modelClasses} from "../constants/outputConstants";
 import {
-    getDrLayout,
-    getDrDatasetPlotData,
-    getDrBmdLine,
-    colorCodes,
     bmaColor,
-    hoverColor,
-    selectedColor,
+    colorCodes,
     getBayesianBMDLine,
+    getDrBmdLine,
+    getDrDatasetPlotData,
+    getDrLayout,
     getLollipopDataset,
     getLollipopPlotLayout,
+    hoverColor,
+    selectedColor,
 } from "../constants/plotting";
 
 class OutputStore {

--- a/frontend/src/stores/RootStore.js
+++ b/frontend/src/stores/RootStore.js
@@ -1,10 +1,10 @@
-import DataStore from "./DataStore";
 import DatasetModelOptionStore from "./DatasetModelOptionStore";
-import OutputStore from "./OutputStore";
-import MainStore from "./MainStore";
-import OptionsStore from "./OptionsStore";
-import ModelsStore from "./ModelsStore";
+import DataStore from "./DataStore";
 import LogicStore from "./LogicStore";
+import MainStore from "./MainStore";
+import ModelsStore from "./ModelsStore";
+import OptionsStore from "./OptionsStore";
+import OutputStore from "./OutputStore";
 
 class RootStore {
     constructor() {

--- a/frontend/src/utils/localHistory.js
+++ b/frontend/src/utils/localHistory.js
@@ -1,7 +1,7 @@
+import _ from "lodash";
 import PropTypes from "prop-types";
 import React from "react";
 import ReactDOM from "react-dom";
-import _ from "lodash";
 
 const KEY = "bmds.data",
     DEFAULT_HISTORY = {enabled: true, history: {}},

--- a/frontend/tests/helpers.js
+++ b/frontend/tests/helpers.js
@@ -1,5 +1,5 @@
-import _ from "lodash";
 import assert from "assert";
+import _ from "lodash";
 
 const isClose = function(actual, expected, atol) {
         return assert.ok(Math.abs(actual - expected) < atol, `|${actual} - ${expected}| > ${atol}`);

--- a/frontend/tests/utils/errorBars.test.js
+++ b/frontend/tests/utils/errorBars.test.js
@@ -1,4 +1,4 @@
-import {inv_tdist_05, continuousErrorBars, dichotomousErrorBars} from "../../src/utils/errorBars";
+import {continuousErrorBars, dichotomousErrorBars, inv_tdist_05} from "../../src/utils/errorBars";
 import assert from "../helpers";
 
 describe("utils/errorBars", function() {

--- a/frontend/tests/utils/formatters.test.js
+++ b/frontend/tests/utils/formatters.test.js
@@ -1,8 +1,8 @@
 import {
     ff,
     fourDecimalFormatter,
-    parameterFormatter,
     fractionalFormatter,
+    parameterFormatter,
 } from "../../src/utils/formatters";
 import assert from "../helpers";
 

--- a/frontend/webpack.base.js
+++ b/frontend/webpack.base.js
@@ -55,7 +55,7 @@ module.exports = {
 
     resolve: {
         alias: {
-            bmd: path.join(__dirname, "src"),
+            "@": path.join(__dirname, "src"),
         },
         modules: [path.join(__dirname, "src"), "node_modules"],
         extensions: [".js", ".css"],


### PR DESCRIPTION
Add [simple-import-sort](https://www.npmjs.com/package/eslint-plugin-simple-import-sort) to eslint to fix and enforce import ordering rules.