### PR TITLE
update typing to py3.11

### DIFF
--- a/bmds_server/analysis/executor.py
+++ b/bmds_server/analysis/executor.py
@@ -1,6 +1,6 @@
 import itertools
 from copy import deepcopy
-from typing import Dict, NamedTuple, Optional
+from typing import NamedTuple, Optional, Self
 
 import bmds
 import numpy as np
@@ -72,7 +72,7 @@ def build_frequentist_session(dataset, inputs, options, dataset_options) -> Opti
 
 
 def build_bayesian_session(
-    dataset: bmds.datasets.DatasetType, inputs: Dict, options: Dict, dataset_options: Dict
+    dataset: bmds.datasets.DatasetType, inputs: dict, options: dict, dataset_options: dict
 ) -> Optional[BmdsSession]:
     models = inputs["models"].get(PriorEnum.bayesian, [])
 
@@ -123,7 +123,7 @@ class AnalysisSession(NamedTuple):
     bayesian: Optional[BmdsSession]
 
     @classmethod
-    def run(cls, inputs: Dict, dataset_index: int, option_index: int) -> AnalysisSessionSchema:
+    def run(cls, inputs: dict, dataset_index: int, option_index: int) -> AnalysisSessionSchema:
         # TODO - replace in BMDS 3.4
         if inputs["dataset_type"] == bmds.constants.NESTED_DICHOTOMOUS:
             return _mock_nested_dichotomous(inputs, dataset_index, option_index)
@@ -135,7 +135,7 @@ class AnalysisSession(NamedTuple):
         return session.to_schema()
 
     @classmethod
-    def create(cls, inputs: Dict, dataset_index: int, option_index: int) -> "AnalysisSession":
+    def create(cls, inputs: dict, dataset_index: int, option_index: int) -> Self:
         dataset = build_dataset(inputs["datasets"][dataset_index])
         options = inputs["options"][option_index]
         dataset_options = inputs["dataset_options"][dataset_index]
@@ -147,7 +147,7 @@ class AnalysisSession(NamedTuple):
         )
 
     @classmethod
-    def deserialize(cls, data: Dict) -> "AnalysisSession":
+    def deserialize(cls, data: dict) -> Self:
         obj = AnalysisSessionSchema.parse_obj(data)
         return cls(
             dataset_index=obj.dataset_index,
@@ -179,7 +179,7 @@ class AnalysisSession(NamedTuple):
         return self.to_schema().dict()
 
 
-def _mock_results(inputs: Dict, dataset_index: int, option_index: int) -> dict:
+def _mock_results(inputs: dict, dataset_index: int, option_index: int) -> dict:
     # TODO - replace in BMDS 3.4
     models = []
     for model_name in itertools.chain(inputs["models"]["frequentist_restricted"]):
@@ -213,12 +213,12 @@ def _mock_results(inputs: Dict, dataset_index: int, option_index: int) -> dict:
     }
 
 
-def _mock_nested_dichotomous(inputs: Dict, dataset_index: int, option_index: int) -> dict:
+def _mock_nested_dichotomous(inputs: dict, dataset_index: int, option_index: int) -> dict:
     # TODO - replace in BMDS 3.4
     return _mock_results(inputs, dataset_index, option_index)
 
 
-def _mock_multitumor(inputs: Dict, dataset_index: int, option_index: int) -> dict:
+def _mock_multitumor(inputs: dict, dataset_index: int, option_index: int) -> dict:
     # TODO - replace in BMDS 3.4
     results = _mock_results(inputs, dataset_index, option_index)
     results["frequentist"]["combined"] = deepcopy(results["frequentist"]["models"][0]["results"])

--- a/bmds_server/analysis/forms.py
+++ b/bmds_server/analysis/forms.py
@@ -1,5 +1,3 @@
-from typing import Tuple
-
 from django import forms
 
 from . import models
@@ -8,7 +6,7 @@ from . import models
 class CreateAnalysisForm(forms.ModelForm):
     class Meta:
         model = models.Analysis
-        fields: Tuple[str, ...] = ()
+        fields: tuple[str, ...] = ()
 
     def save(self, commit=True):
         self.instance.inputs = self.instance.default_input()

--- a/bmds_server/analysis/models.py
+++ b/bmds_server/analysis/models.py
@@ -4,7 +4,7 @@ import uuid
 from copy import deepcopy
 from datetime import timedelta
 from io import BytesIO
-from typing import Dict, List, Optional
+from typing import Optional
 
 import bmds
 import pandas as pd
@@ -145,7 +145,7 @@ class Analysis(models.Model):
             raise ValueError("Session cannot be returned")
         return executor.AnalysisSession.deserialize(deepcopy(self.outputs["outputs"][index]))
 
-    def get_sessions(self) -> List[executor.AnalysisSession]:
+    def get_sessions(self) -> list[executor.AnalysisSession]:
         if not self.is_finished or self.has_errors:
             raise ValueError("Session cannot be returned")
         return [
@@ -154,7 +154,7 @@ class Analysis(models.Model):
         ]
 
     def to_batch(self) -> BmdsSessionBatch:
-        # convert List[executor.AnalysisSession] to List[bmds.BmdsSession]
+        # convert list[executor.AnalysisSession] to list[bmds.BmdsSession]
         items = []
         for session in self.get_sessions():
             if session.frequentist:
@@ -211,7 +211,7 @@ class Analysis(models.Model):
             self.handle_execution_error(err)
 
     def try_run_session(
-        self, inputs: Dict, dataset_index: int, option_index: int
+        self, inputs: dict, dataset_index: int, option_index: int
     ) -> AnalysisSessionSchema:
         try:
             return executor.AnalysisSession.run(inputs, dataset_index, option_index)
@@ -285,7 +285,7 @@ class Analysis(models.Model):
         self.deletion_date = None  # don't delete; save for troubleshooting
         self.save()
 
-    def default_input(self) -> Dict:
+    def default_input(self) -> dict:
         return {
             "bmds_version": bmds.constants.BMDS330,
             "dataset_type": Dtype.DICHOTOMOUS,
@@ -339,7 +339,7 @@ class Content(models.Model):
         super().save(*args, **kwargs)
         self.update_cache()
 
-    def update_cache(self) -> Dict:
+    def update_cache(self) -> dict:
         key = self.cache_name(self.content_type)
         cache.set(key, self.content, 3600)  # cache for an hour
         return self.content
@@ -349,7 +349,7 @@ class Content(models.Model):
         return f"{cls._meta.db_table}-{content_type}"
 
     @classmethod
-    def get_cached_content(cls, content_type: ContentType) -> Dict:
+    def get_cached_content(cls, content_type: ContentType) -> dict:
         key = cls.cache_name(content_type)
         content = cache.get(key)
         if content is None:

--- a/bmds_server/analysis/transforms.py
+++ b/bmds_server/analysis/transforms.py
@@ -1,6 +1,5 @@
 from copy import deepcopy
 from enum import Enum
-from typing import Union
 
 import bmds
 from bmds.bmds3.types.continuous import ContinuousModelSettings
@@ -35,7 +34,7 @@ def build_model_settings(
     prior_class: str,
     options: dict,
     dataset_options: dict,
-) -> Union[DichotomousModelSettings, ContinuousModelSettings]:
+) -> DichotomousModelSettings | ContinuousModelSettings:
     prior_class = bmd3_prior_map[prior_class]
     if dataset_type in bmds.constants.DICHOTOMOUS_DTYPES:
         return DichotomousModelSettings(

--- a/bmds_server/analysis/transforms.py
+++ b/bmds_server/analysis/transforms.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from enum import Enum
+from enum import StrEnum
 
 import bmds
 from bmds.bmds3.types.continuous import ContinuousModelSettings
@@ -11,7 +11,7 @@ from bmds.constants import Dtype
 from .validators.datasets import AdverseDirection
 
 
-class PriorEnum(str, Enum):
+class PriorEnum(StrEnum):
     frequentist_restricted = "frequentist_restricted"
     frequentist_unrestricted = "frequentist_unrestricted"
     bayesian = "bayesian"

--- a/bmds_server/analysis/transforms.py
+++ b/bmds_server/analysis/transforms.py
@@ -1,6 +1,6 @@
 from copy import deepcopy
 from enum import Enum
-from typing import Dict, List, Union
+from typing import Union
 
 import bmds
 from bmds.bmds3.types.continuous import ContinuousModelSettings
@@ -33,8 +33,8 @@ is_increasing_map = {
 def build_model_settings(
     dataset_type: str,
     prior_class: str,
-    options: Dict,
-    dataset_options: Dict,
+    options: dict,
+    dataset_options: dict,
 ) -> Union[DichotomousModelSettings, ContinuousModelSettings]:
     prior_class = bmd3_prior_map[prior_class]
     if dataset_type in bmds.constants.DICHOTOMOUS_DTYPES:
@@ -70,7 +70,7 @@ def build_model_settings(
         raise ValueError(f"Unknown dataset_type: {dataset_type}")
 
 
-def build_dataset(dataset: Dict[str, List[float]]) -> bmds.datasets.DatasetType:
+def build_dataset(dataset: dict[str, list[float]]) -> bmds.datasets.DatasetType:
     dataset_type = dataset["dtype"]
     if dataset_type == Dtype.CONTINUOUS:
         schema = bmds.datasets.ContinuousDatasetSchema
@@ -85,7 +85,7 @@ def build_dataset(dataset: Dict[str, List[float]]) -> bmds.datasets.DatasetType:
     return schema.parse_obj(dataset).deserialize()
 
 
-def remap_exponential(models: List[str]) -> List[str]:
+def remap_exponential(models: list[str]) -> list[str]:
     # recursively expand user-specified "exponential" model into M3 and M5
     if bmds.constants.M_Exponential in models:
         models = models.copy()  # return a copy so inputs are unchanged
@@ -94,7 +94,7 @@ def remap_exponential(models: List[str]) -> List[str]:
     return models
 
 
-def remap_bayesian_exponential(models: List[Dict]) -> List[Dict]:
+def remap_bayesian_exponential(models: list[dict]) -> list[dict]:
     for i, model in enumerate(models):
         if model["model"] == bmds.constants.M_Exponential:
             models = deepcopy(models)

--- a/bmds_server/analysis/validators/__init__.py
+++ b/bmds_server/analysis/validators/__init__.py
@@ -1,5 +1,3 @@
-from typing import Dict
-
 import bmds
 from bmds.bmds3.recommender import RecommenderSettings
 
@@ -11,12 +9,12 @@ from .selectors import AnalysisSelectedSchema  # noqa: F401
 from .session import validate_session
 
 
-def validate_input(data: Dict, partial: bool = False) -> None:
+def validate_input(data: dict, partial: bool = False) -> None:
     """
     Validate input payload.
 
     Args:
-        data (Dict): the data payload
+        data (dict): the data payload
         partial (bool): validate a partial input
 
     Raises:

--- a/bmds_server/analysis/validators/datasets.py
+++ b/bmds_server/analysis/validators/datasets.py
@@ -1,5 +1,5 @@
 from enum import IntEnum
-from typing import Any, ClassVar, Union
+from typing import Any, ClassVar
 
 import bmds
 from bmds.datasets import (
@@ -87,7 +87,7 @@ class DichotomousDatasets(DatasetValidator):
 class ContinuousDatasets(DatasetValidator):
     dataset_options: conlist(ContinuousModelOptions, min_items=1, max_items=10)
     datasets: conlist(
-        Union[MaxContinuousDatasetSchema, MaxContinuousIndividualDatasetSchema],
+        MaxContinuousDatasetSchema | MaxContinuousIndividualDatasetSchema,
         min_items=1,
         max_items=10,
     )

--- a/bmds_server/analysis/validators/models.py
+++ b/bmds_server/analysis/validators/models.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Set
+from typing import Any
 
 import bmds
 import numpy as np
@@ -9,9 +9,9 @@ from ...common.validation import pydantic_validate
 
 
 class ModelTypeSchema(BaseModel):
-    restricted: Set[str]
-    unrestricted: Set[str]
-    bayesian: Set[str]
+    restricted: set[str]
+    unrestricted: set[str]
+    bayesian: set[str]
 
 
 DichotomousModelSchema = ModelTypeSchema(
@@ -45,10 +45,10 @@ class BayesianModelSchema(BaseModel):
     prior_weight: confloat(ge=0, le=1)
 
 
-class ModelListSchema(BaseModel):
-    frequentist_restricted: List[str] = []
-    frequentist_unrestricted: List[str] = []
-    bayesian: List[BayesianModelSchema] = []
+class ModellistSchema(BaseModel):
+    frequentist_restricted: list[str] = []
+    frequentist_unrestricted: list[str] = []
+    bayesian: list[BayesianModelSchema] = []
     model_schema: ModelTypeSchema
 
     @validator("bayesian")
@@ -98,29 +98,29 @@ class ModelListSchema(BaseModel):
         return values
 
 
-class DichotomousModelListSchema(ModelListSchema):
+class DichotomousModellistSchema(ModellistSchema):
     model_schema: ModelTypeSchema = DichotomousModelSchema
 
 
-class ContinuousModelListSchema(ModelListSchema):
+class ContinuousModellistSchema(ModellistSchema):
     model_schema: ModelTypeSchema = ContinuousModelSchema
 
 
-class NestedDichotomousModelListSchema(ModelListSchema):
+class NestedDichotomousModellistSchema(ModellistSchema):
     model_schema: ModelTypeSchema = NestedDichotomousModelSchema
 
 
-class MultiTumorModelListSchema(ModelListSchema):
+class MultiTumorModellistSchema(ModellistSchema):
     model_schema: ModelTypeSchema = MultiTumorModelSchema
 
 
 schema_map = {
-    bmds.constants.DICHOTOMOUS: DichotomousModelListSchema,
-    bmds.constants.DICHOTOMOUS_CANCER: DichotomousModelListSchema,
-    bmds.constants.CONTINUOUS: ContinuousModelListSchema,
-    bmds.constants.CONTINUOUS_INDIVIDUAL: ContinuousModelListSchema,
-    bmds.constants.NESTED_DICHOTOMOUS: NestedDichotomousModelListSchema,
-    bmds.constants.MULTI_TUMOR: MultiTumorModelListSchema,
+    bmds.constants.DICHOTOMOUS: DichotomousModellistSchema,
+    bmds.constants.DICHOTOMOUS_CANCER: DichotomousModellistSchema,
+    bmds.constants.CONTINUOUS: ContinuousModellistSchema,
+    bmds.constants.CONTINUOUS_INDIVIDUAL: ContinuousModellistSchema,
+    bmds.constants.NESTED_DICHOTOMOUS: NestedDichotomousModellistSchema,
+    bmds.constants.MULTI_TUMOR: MultiTumorModellistSchema,
 }
 
 

--- a/bmds_server/analysis/validators/models.py
+++ b/bmds_server/analysis/validators/models.py
@@ -45,7 +45,7 @@ class BayesianModelSchema(BaseModel):
     prior_weight: confloat(ge=0, le=1)
 
 
-class ModellistSchema(BaseModel):
+class ModelListSchema(BaseModel):
     frequentist_restricted: list[str] = []
     frequentist_unrestricted: list[str] = []
     bayesian: list[BayesianModelSchema] = []
@@ -98,29 +98,29 @@ class ModellistSchema(BaseModel):
         return values
 
 
-class DichotomousModellistSchema(ModellistSchema):
+class DichotomousModelListSchema(ModelListSchema):
     model_schema: ModelTypeSchema = DichotomousModelSchema
 
 
-class ContinuousModellistSchema(ModellistSchema):
+class ContinuousModelListSchema(ModelListSchema):
     model_schema: ModelTypeSchema = ContinuousModelSchema
 
 
-class NestedDichotomousModellistSchema(ModellistSchema):
+class NestedDichotomousModelListSchema(ModelListSchema):
     model_schema: ModelTypeSchema = NestedDichotomousModelSchema
 
 
-class MultiTumorModellistSchema(ModellistSchema):
+class MultiTumorModelListSchema(ModelListSchema):
     model_schema: ModelTypeSchema = MultiTumorModelSchema
 
 
 schema_map = {
-    bmds.constants.DICHOTOMOUS: DichotomousModellistSchema,
-    bmds.constants.DICHOTOMOUS_CANCER: DichotomousModellistSchema,
-    bmds.constants.CONTINUOUS: ContinuousModellistSchema,
-    bmds.constants.CONTINUOUS_INDIVIDUAL: ContinuousModellistSchema,
-    bmds.constants.NESTED_DICHOTOMOUS: NestedDichotomousModellistSchema,
-    bmds.constants.MULTI_TUMOR: MultiTumorModellistSchema,
+    bmds.constants.DICHOTOMOUS: DichotomousModelListSchema,
+    bmds.constants.DICHOTOMOUS_CANCER: DichotomousModelListSchema,
+    bmds.constants.CONTINUOUS: ContinuousModelListSchema,
+    bmds.constants.CONTINUOUS_INDIVIDUAL: ContinuousModelListSchema,
+    bmds.constants.NESTED_DICHOTOMOUS: NestedDichotomousModelListSchema,
+    bmds.constants.MULTI_TUMOR: MultiTumorModelListSchema,
 }
 
 

--- a/bmds_server/analysis/validators/session.py
+++ b/bmds_server/analysis/validators/session.py
@@ -1,8 +1,7 @@
-from typing import Any, Dict, Optional, Union
+from typing import Any, Literal, Optional, Union
 
 import bmds
 from pydantic import BaseModel, conlist
-from pydantic.typing import Literal
 
 from ...common.validation import pydantic_validate
 
@@ -18,10 +17,10 @@ class BaseSession(BaseModel):
 
 class BaseSessionComplete(BaseSession):
     datasets: conlist(Any, min_items=1, max_items=10)
-    models: Dict
+    models: dict
     options: conlist(Any, min_items=1, max_items=10)
 
 
-def validate_session(data: Dict, partial: bool = False):
+def validate_session(data: dict, partial: bool = False):
     schema = BaseSession if partial else BaseSessionComplete
     pydantic_validate(data, schema)

--- a/bmds_server/analysis/validators/session.py
+++ b/bmds_server/analysis/validators/session.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal, Optional, Union
+from typing import Any, Literal
 
 import bmds
 from pydantic import BaseModel, conlist
@@ -9,7 +9,7 @@ _versions = Literal[bmds.constants.BMDS330]
 
 
 class BaseSession(BaseModel):
-    id: Optional[Union[int, str]]
+    id: int | str | None
     bmds_version: _versions
     description: str = ""
     dataset_type: bmds.constants.ModelClass

--- a/bmds_server/analysis/views.py
+++ b/bmds_server/analysis/views.py
@@ -1,4 +1,4 @@
-from typing import Optional, Tuple
+from typing import Optional
 
 from django.conf import settings
 from django.contrib.admin.views.decorators import staff_member_required
@@ -48,7 +48,7 @@ class Analytics(TemplateView):
         return super().get_context_data(**kwargs)
 
 
-def get_analysis_or_404(pk: str, password: Optional[str] = "") -> Tuple[models.Analysis, bool]:
+def get_analysis_or_404(pk: str, password: Optional[str] = "") -> tuple[models.Analysis, bool]:
     """Return an analysis object and if a correct password is provided for this object.
 
     Args:
@@ -56,7 +56,7 @@ def get_analysis_or_404(pk: str, password: Optional[str] = "") -> Tuple[models.A
         password (Optional[str]): A edit password for this analysis
 
     Returns:
-        Tuple[models.Analysis, bool]: An analysis object and if it has a correct password
+        tuple[models.Analysis, bool]: An analysis object and if it has a correct password
 
     Raises:
         Http404: if the selected object cannot be found

--- a/bmds_server/common/git.py
+++ b/bmds_server/common/git.py
@@ -1,5 +1,6 @@
 import subprocess
 from datetime import datetime
+from typing import Self
 
 from pydantic import BaseModel
 
@@ -9,7 +10,7 @@ class Commit(BaseModel):
     dt: datetime
 
     @classmethod
-    def current(cls, cwd: str = ".") -> "Commit":
+    def current(cls, cwd: str = ".") -> Self:
         """Return information on the last commit at the repository path desired.
 
         Returns:

--- a/bmds_server/common/renderers.py
+++ b/bmds_server/common/renderers.py
@@ -1,6 +1,6 @@
 import json
 from io import BytesIO, StringIO
-from typing import NamedTuple, Union
+from typing import NamedTuple
 
 import matplotlib.pyplot as plt
 from matplotlib.axes import Axes
@@ -25,7 +25,7 @@ class XlsxRenderer(BaseRenderer):
     media_type = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
     format = "xlsx"
 
-    def render(self, dataset: Union[dict, BinaryFile], media_type=None, renderer_context=None):
+    def render(self, dataset: dict | BinaryFile, media_type=None, renderer_context=None):
         if isinstance(dataset, dict):
             return json.dumps(dataset).encode()
 
@@ -38,7 +38,7 @@ class DocxRenderer(BaseRenderer):
     media_type = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
     format = "docx"
 
-    def render(self, dataset: Union[dict, BinaryFile], media_type=None, renderer_context=None):
+    def render(self, dataset: dict | BinaryFile, media_type=None, renderer_context=None):
         if isinstance(dataset, dict):
             return json.dumps(dataset).encode()
 

--- a/bmds_server/common/renderers.py
+++ b/bmds_server/common/renderers.py
@@ -1,6 +1,6 @@
 import json
 from io import BytesIO, StringIO
-from typing import Dict, NamedTuple, Union
+from typing import NamedTuple, Union
 
 import matplotlib.pyplot as plt
 from matplotlib.axes import Axes
@@ -25,7 +25,7 @@ class XlsxRenderer(BaseRenderer):
     media_type = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
     format = "xlsx"
 
-    def render(self, dataset: Union[Dict, BinaryFile], media_type=None, renderer_context=None):
+    def render(self, dataset: Union[dict, BinaryFile], media_type=None, renderer_context=None):
         if isinstance(dataset, dict):
             return json.dumps(dataset).encode()
 
@@ -38,7 +38,7 @@ class DocxRenderer(BaseRenderer):
     media_type = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
     format = "docx"
 
-    def render(self, dataset: Union[Dict, BinaryFile], media_type=None, renderer_context=None):
+    def render(self, dataset: Union[dict, BinaryFile], media_type=None, renderer_context=None):
         if isinstance(dataset, dict):
             return json.dumps(dataset).encode()
 

--- a/bmds_server/common/views.py
+++ b/bmds_server/common/views.py
@@ -1,7 +1,7 @@
 import logging
 from pprint import pformat
 from textwrap import dedent
-from typing import Any, Dict
+from typing import Any
 
 from django.conf import settings
 from django.contrib.admin.views.decorators import staff_member_required
@@ -53,7 +53,7 @@ class AdminLoginView(LoginView):
             return HttpResponseRedirect(reverse("external_auth"))
         return super().dispatch(request, *args, **kwargs)
 
-    def get_context_data(self, **kwargs: Any) -> Dict[str, Any]:
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)
         context["auth_providers"] = settings.AUTH_PROVIDERS
         return context
@@ -64,7 +64,7 @@ class AdminLoginView(LoginView):
 
 
 class ExternalAuth(View):
-    def get_user_metadata(self, request) -> Dict:
+    def get_user_metadata(self, request) -> dict:
         """
         Retrieve user metadata from request to use for authentication.
 
@@ -75,7 +75,7 @@ class ExternalAuth(View):
             request: incoming request
 
         Returns:
-            Dict: user metadata; must include "email" and "username" keys
+            dict: user metadata; must include "email" and "username" keys
         """
         raise NotImplementedError("Deployment specific; requires implementation")
 

--- a/bmds_server/common/worker_health.py
+++ b/bmds_server/common/worker_health.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timedelta, timezone
-from typing import Dict
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -56,7 +55,7 @@ class WorkerHealthcheck:
         series = self.series()
         return event_plot(series)
 
-    def stats(self) -> Dict:
+    def stats(self) -> dict:
         inspect = app.control.inspect()
         stats = dict(ping=inspect.ping())
         if stats["ping"]:

--- a/bmds_server/main/constants.py
+++ b/bmds_server/main/constants.py
@@ -1,7 +1,7 @@
-from enum import Enum, IntEnum
+from enum import IntEnum, StrEnum
 
 
-class AuthProvider(str, Enum):
+class AuthProvider(StrEnum):
     django = "django"
     external = "external"
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ classifiers =
 zip_safe = False
 include_package_data = True
 packages = find:
+requires-python = ">=3.11"
 
 [options.package_data]
 * =

--- a/tests/analysis/test_validators.py
+++ b/tests/analysis/test_validators.py
@@ -1,6 +1,6 @@
 import json
 from copy import deepcopy
-from typing import Any, Dict
+from typing import Any
 
 import bmds
 import pytest
@@ -19,7 +19,7 @@ def _missing_field(err, missing_field: str):
 
 class TestInputValidation:
     def test_bmds3_partial(self):
-        data: Dict[str, Any] = {
+        data: dict[str, Any] = {
             "bmds_version": bmds.constants.BMDS330,
             "dataset_type": bmds.constants.CONTINUOUS,
         }
@@ -89,7 +89,7 @@ class TestInputValidation:
         _missing_field(err, "rules")
 
     def test_nested_dichotomous(self, nested_dichotomous_datasets):
-        data: Dict[str, Any] = {
+        data: dict[str, Any] = {
             "bmds_version": bmds.constants.BMDS330,
             "dataset_type": bmds.constants.NESTED_DICHOTOMOUS,
         }
@@ -135,7 +135,7 @@ class TestInputValidation:
         assert validators.validate_input(data) is None
 
     def test_multi_tumor(self):
-        data: Dict[str, Any] = {
+        data: dict[str, Any] = {
             "bmds_version": bmds.constants.BMDS330,
             "dataset_type": bmds.constants.MULTI_TUMOR,
         }


### PR DESCRIPTION
Add `require-python` >= 3.11 to the package, since we're using some type annotation features

- update typing to use built-in dict, list, set, tuple (python 3.9)
- Use | for Union (python 3.10)
- use Self for returning a class instance (python 3.11)
- use StrEnum (python 3.11)