### PR TITLE
django 4.2 LTS + ruff

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,6 @@ dev: ## Start developer environment.
 	./bin/dev.sh
 
 test: ## This runs all of the tests.
-
 	# To run tests:
 	#
 	#  py.test --ds=bmds_server.settings.dev
@@ -71,20 +70,20 @@ loc: ## Generate lines of code report
 		--counted loc-files.txt \
 		.
 
-lint: lint-py lint-js  ## Check for javascript/python for linting issues
+lint: lint-py lint-js  ## Check formatting issues
 
-format: format-py format-js  ## Modify javascript/python code
+format: format-py format-js  ## Fix formatting issues where possible
 
-lint-py:  ## Check for python formatting issues via black & flake8
-	@black . --check && isort -q --check . && flake8 .
+lint-py:  ## Check python formatting issues
+	@black . --check && ruff .
 
-format-py:  ## Modify python code using black & show flake8 issues
-	@black . && isort -q . && flake8 .
+format-py:  ## Fix python formatting issues where possible
+	@black . && ruff . --fix
 
-lint-js:  ## Check for javascript formatting issues
+lint-js:  ## Check javascript formatting issues
 	@npm --prefix ./frontend run lint
 
-format-js:  ## Modify javascript code if possible using linters/formatters
+format-js:  ## Fix javascript formatting issues where possible
 	@npm --prefix ./frontend run format
 
 sync-dev:  ## Sync dev environment after code checkout

--- a/bmds_server/analysis/admin.py
+++ b/bmds_server/analysis/admin.py
@@ -34,15 +34,13 @@ class AnalysisAdmin(VersionAdmin):
         "deletion_date",
     )
 
+    @admin.display(description="View")
     def view_url(self, obj):
         return format_html(f"<a href='{obj.get_absolute_url()}'>View</a>")
 
-    view_url.short_description = "View"
-
+    @admin.display(description="Edit")
     def edit_url(self, obj):
         return format_html(f"<a href='{obj.get_edit_url()}'>Edit</a>")
-
-    edit_url.short_description = "Edit"
 
 
 @admin.register(models.Content)

--- a/bmds_server/analysis/executor.py
+++ b/bmds_server/analysis/executor.py
@@ -1,6 +1,6 @@
 import itertools
 from copy import deepcopy
-from typing import NamedTuple, Optional, Self
+from typing import NamedTuple, Self
 
 import bmds
 import numpy as np
@@ -20,7 +20,7 @@ from .transforms import (
 lognormal_enabled = {bmds.constants.M_ExponentialM3, bmds.constants.M_ExponentialM5}
 
 
-def build_frequentist_session(dataset, inputs, options, dataset_options) -> Optional[BmdsSession]:
+def build_frequentist_session(dataset, inputs, options, dataset_options) -> BmdsSession | None:
     restricted_models = inputs["models"].get(PriorEnum.frequentist_restricted, [])
     unrestricted_models = inputs["models"].get(PriorEnum.frequentist_unrestricted, [])
 
@@ -73,7 +73,7 @@ def build_frequentist_session(dataset, inputs, options, dataset_options) -> Opti
 
 def build_bayesian_session(
     dataset: bmds.datasets.DatasetType, inputs: dict, options: dict, dataset_options: dict
-) -> Optional[BmdsSession]:
+) -> BmdsSession | None:
     models = inputs["models"].get(PriorEnum.bayesian, [])
 
     # filter lognormal
@@ -119,8 +119,8 @@ class AnalysisSession(NamedTuple):
 
     dataset_index: int
     option_index: int
-    frequentist: Optional[BmdsSession]
-    bayesian: Optional[BmdsSession]
+    frequentist: BmdsSession | None
+    bayesian: BmdsSession | None
 
     @classmethod
     def run(cls, inputs: dict, dataset_index: int, option_index: int) -> AnalysisSessionSchema:

--- a/bmds_server/analysis/management/commands/delete_old_jobs.py
+++ b/bmds_server/analysis/management/commands/delete_old_jobs.py
@@ -7,7 +7,6 @@ from django.utils.timezone import now
 
 
 class Command(BaseCommand):
-
     help = "Delete old results which are older than N days."
 
     def handle(self, *args, **options):

--- a/bmds_server/analysis/migrations/0001_initial.py
+++ b/bmds_server/analysis/migrations/0001_initial.py
@@ -7,7 +7,6 @@ from ..models import get_deletion_date
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/bmds_server/analysis/migrations/0002_fixtures.py
+++ b/bmds_server/analysis/migrations/0002_fixtures.py
@@ -9,7 +9,6 @@ def load_fixture(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [("analysis", "0001_initial")]

--- a/bmds_server/analysis/migrations/0003_reversions.py
+++ b/bmds_server/analysis/migrations/0003_reversions.py
@@ -11,7 +11,6 @@ def remove_revisions(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("analysis", "0002_fixtures"),
         ("reversion", "0001_squashed_0004_auto_20160611_1202"),

--- a/bmds_server/analysis/models.py
+++ b/bmds_server/analysis/models.py
@@ -4,7 +4,6 @@ import uuid
 from copy import deepcopy
 from datetime import timedelta
 from io import BytesIO
-from typing import Optional
 
 import bmds
 import pandas as pd
@@ -299,19 +298,19 @@ class Analysis(models.Model):
     def renew(self):
         self.deletion_date = get_deletion_date(self.deletion_date)
 
-    def get_bmds_version(self) -> Optional[VersionSchema]:
+    def get_bmds_version(self) -> VersionSchema | None:
         if not self.is_finished or self.has_errors:
             return None
         return AnalysisOutput.parse_obj(self.outputs).bmds_python_version
 
     @property
-    def deletion_date_str(self) -> Optional[str]:
+    def deletion_date_str(self) -> str | None:
         if self.deletion_date is None:
             return None
         return self.deletion_date.strftime("%B %d, %Y")
 
     @property
-    def days_until_deletion(self) -> Optional[int]:
+    def days_until_deletion(self) -> int | None:
         if self.deletion_date is None:
             return None
         return (self.deletion_date - now()).days

--- a/bmds_server/analysis/schema.py
+++ b/bmds_server/analysis/schema.py
@@ -1,5 +1,4 @@
 from io import StringIO
-from typing import Optional
 
 import pandas as pd
 from bmds.bmds3.types.sessions import VersionSchema
@@ -23,16 +22,16 @@ class WrappedAnalysisSelectedSchema(BaseModel):
 class AnalysisSessionSchema(BaseModel):
     dataset_index: int
     option_index: int
-    frequentist: Optional[dict]
-    bayesian: Optional[dict]
-    error: Optional[str]
+    frequentist: dict | None
+    bayesian: dict | None
+    error: str | None
 
 
 class AnalysisOutput(BaseModel):
     analysis_id: str
     analysis_schema_version: str = "1.0"
     bmds_server_version: str
-    bmds_python_version: Optional[VersionSchema]
+    bmds_python_version: VersionSchema | None
     outputs: list[AnalysisSessionSchema]
 
 
@@ -40,7 +39,7 @@ class PolyKInput(BaseModel):
     dataset: str
     dose_units: str
     power: confloat(ge=0, le=5) = 3
-    duration: Optional[confloat(ge=0, le=10_000)] = None
+    duration: confloat(ge=0, le=10000) | None = None
 
     @validator("dataset")
     def check_dataset(cls, value):

--- a/bmds_server/analysis/views.py
+++ b/bmds_server/analysis/views.py
@@ -1,5 +1,3 @@
-from typing import Optional
-
 from django.conf import settings
 from django.contrib.admin.views.decorators import staff_member_required
 from django.middleware.csrf import get_token
@@ -48,7 +46,7 @@ class Analytics(TemplateView):
         return super().get_context_data(**kwargs)
 
 
-def get_analysis_or_404(pk: str, password: Optional[str] = "") -> tuple[models.Analysis, bool]:
+def get_analysis_or_404(pk: str, password: str | None = "") -> tuple[models.Analysis, bool]:
     """Return an analysis object and if a correct password is provided for this object.
 
     Args:

--- a/bmds_server/common/management/commands/dump_test_db.py
+++ b/bmds_server/common/management/commands/dump_test_db.py
@@ -10,7 +10,6 @@ class Command(BaseCommand):
     help = """Dump test database into a fixture."""
 
     def handle(self, *args, **options):
-
         if "fixture" not in settings.DATABASES["default"]["NAME"]:
             raise CommandError("Must be using a test database to execute.")
 

--- a/bmds_server/common/management/commands/load_test_db.py
+++ b/bmds_server/common/management/commands/load_test_db.py
@@ -16,7 +16,6 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-
         if not any(_ in settings.DATABASES["default"]["NAME"] for _ in ["fixture", "test"]):
             raise CommandError("Must be using a test database to execute.")
 

--- a/bmds_server/common/renderers.py
+++ b/bmds_server/common/renderers.py
@@ -8,7 +8,6 @@ from rest_framework.renderers import BaseRenderer
 
 
 class TxtRenderer(BaseRenderer):
-
     media_type = "text/plain"
     format = "txt"
 

--- a/bmds_server/common/task_cache.py
+++ b/bmds_server/common/task_cache.py
@@ -1,6 +1,6 @@
 import abc
 from enum import IntEnum
-from typing import Any, Optional
+from typing import Any
 
 from django.core.cache import cache
 from pydantic import BaseModel
@@ -13,9 +13,9 @@ class ReportStatus(IntEnum):
 
 class ReportResponse(BaseModel):
     status: ReportStatus
-    content: Optional[Any]
-    header: Optional[str]
-    message: Optional[str]
+    content: Any | None
+    header: str | None
+    message: str | None
 
 
 class ReportCache(abc.ABC):

--- a/bmds_server/common/templatetags/bs4.py
+++ b/bmds_server/common/templatetags/bs4.py
@@ -2,7 +2,6 @@
 Twitter Bootstrap 4 - helper methods
 """
 from textwrap import dedent
-from typing import Optional
 from uuid import uuid4
 
 from django import template
@@ -41,7 +40,7 @@ def icon(name: str):
 
 
 @register.simple_tag()
-def plotly(fig: Optional[Figure]) -> str:
+def plotly(fig: Figure) -> str | None:
     """Generate a plotly figure"""
     if fig is None:
         return ""

--- a/bmds_server/common/utils.py
+++ b/bmds_server/common/utils.py
@@ -1,9 +1,9 @@
 import logging
 import random
 import string
+from collections.abc import Callable
 from datetime import datetime
 from functools import wraps
-from typing import Callable, Optional
 
 from django.core.cache import cache
 
@@ -19,14 +19,14 @@ def random_string(samples: str = _random_string_pool, length: int = 12) -> str:
         samples (str, optional): Random characters to select from.
         length (int, optional): Size of generated string; defaults to 12.
     """
-    return "".join(random.choices(_random_string_pool, k=length))
+    return "".join(random.choices(_random_string_pool, k=length))  # noqa: S311
 
 
 def to_timestamp(dt: datetime) -> str:
     return dt.strftime("%Y-%b-%d %H:%m %Z")
 
 
-def get_bool(value: Optional[str]) -> bool:
+def get_bool(value: str | None) -> bool:
     return value is not None and value.lower() == "true"
 
 

--- a/bmds_server/common/validation.py
+++ b/bmds_server/common/validation.py
@@ -1,4 +1,4 @@
-from typing import Any, Type, TypeVar
+from typing import Any, TypeVar
 
 from django.core.exceptions import ValidationError
 from pydantic import BaseModel
@@ -7,7 +7,7 @@ from pydantic import ValidationError as PydanticValidationError
 T = TypeVar("T", bound=BaseModel)
 
 
-def pydantic_validate(data: Any, model: Type[T]) -> T:
+def pydantic_validate(data: Any, model: type[T]) -> T:
     """Attempt to validate incoming data using Pydantic model class.
 
     Args:

--- a/bmds_server/common/worker_health.py
+++ b/bmds_server/common/worker_health.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -31,7 +31,7 @@ class WorkerHealthcheck:
         """
         conn = self._get_conn()
         pipeline = conn.pipeline()
-        pipeline.lpush(self.KEY, datetime.now(timezone.utc).timestamp())
+        pipeline.lpush(self.KEY, datetime.now(UTC).timestamp())
         pipeline.ltrim(self.KEY, 0, self.MAX_SIZE - 1)
         pipeline.execute()
 
@@ -41,8 +41,8 @@ class WorkerHealthcheck:
         last_push = conn.lindex(self.KEY, 0)
         if last_push is None:
             return False
-        last_ping = datetime.fromtimestamp(float(last_push), timezone.utc)
-        return datetime.now(timezone.utc) - last_ping < self.MAX_WAIT
+        last_ping = datetime.fromtimestamp(float(last_push), UTC)
+        return datetime.now(UTC) - last_ping < self.MAX_WAIT
 
     def series(self) -> pd.Series:
         """Return a pd.Series of last successful times"""

--- a/bmds_server/main/urls.py
+++ b/bmds_server/main/urls.py
@@ -1,7 +1,6 @@
 from django.conf import settings
-from django.conf.urls import include
 from django.contrib import admin
-from django.urls import path
+from django.urls import include, path
 from django.views.generic import TemplateView
 from rest_framework import permissions
 from rest_framework.routers import SimpleRouter

--- a/bmds_server/templates/admin/base.html
+++ b/bmds_server/templates/admin/base.html
@@ -6,7 +6,7 @@
         <a href="{{ site_url }}">{% translate 'View site' %}</a> /
     {% endif %}
     <a href="{% url 'analytics' %}">{% translate 'Analytics' %}</a> /
-    <a href="{% url 'swagger' %}">{% translate 'Swagger UI' %}</a> /
+    <a href="{% url 'swagger' %}">{% translate 'Swagger' %}</a> /
     {% if user.is_active and user.is_staff %}
         {% url 'django-admindocs-docroot' as docsroot %}
         {% if docsroot %}
@@ -17,4 +17,5 @@
     <a href="{% url 'admin:password_change' %}">{% translate 'Change password' %}</a> /
     {% endif %}
     <a href="{% url 'admin:logout' %}">{% translate 'Log out' %}</a>
+    {% include "admin/color_theme_toggle.html" %}
 {% endblock %}

--- a/bmds_server/templates/admin/base.html
+++ b/bmds_server/templates/admin/base.html
@@ -7,15 +7,6 @@
     {% endif %}
     <a href="{% url 'analytics' %}">{% translate 'Analytics' %}</a> /
     <a href="{% url 'swagger' %}">{% translate 'Swagger' %}</a> /
-    {% if user.is_active and user.is_staff %}
-        {% url 'django-admindocs-docroot' as docsroot %}
-        {% if docsroot %}
-            <a href="{{ docsroot }}">{% translate 'Documentation' %}</a> /
-        {% endif %}
-    {% endif %}
-    {% if user.has_usable_password %}
-    <a href="{% url 'admin:password_change' %}">{% translate 'Change password' %}</a> /
-    {% endif %}
     <a href="{% url 'admin:logout' %}">{% translate 'Log out' %}</a>
     {% include "admin/color_theme_toggle.html" %}
 {% endblock %}

--- a/compose/app/test.py
+++ b/compose/app/test.py
@@ -6,4 +6,4 @@ dataset = bmds.DichotomousDataset(
 )
 model = Logistic(dataset=dataset)
 result = model.execute()
-print(result.dict())
+print(result.dict())  # noqa: T201

--- a/docs/docs/development.md
+++ b/docs/docs/development.md
@@ -89,6 +89,7 @@ Recommended extensions:
 
 - [Python](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
 - [Eslint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
+- [Ruff](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff)
 
 Recommended workspace settings:
 
@@ -99,7 +100,11 @@ Recommended workspace settings:
         "editor.formatOnSave": false
     },
     "[python]": {
-        "editor.formatOnSave": true
+        "editor.formatOnSave": true,
+        "editor.formatOnPaste": false,
+        "editor.codeActionsOnSave": {
+            "source.fixAll": true
+        }
     },
     "[javascript]": {
         "editor.formatOnSave": false,
@@ -108,10 +113,8 @@ Recommended workspace settings:
         }
     },
     "editor.formatOnSave": true,
+    "python.linting.flake8Enabled": false,
     "python.pythonPath": "./venv/bin/python",
-    "python.linting.flake8Args": [
-        "--config=.flake8"
-    ],
     "eslint.workingDirectories": [
         "./frontend"
     ]

--- a/make.bat
+++ b/make.bat
@@ -22,14 +22,14 @@ echo.  sync-dev     sync dev environment after code checkout
 echo.  docs         make documentation
 echo.  docs-serve   serve documentation for writing
 echo.  test         perform both test-py and test-js
-echo.  lint         perform both lint-py and lint-js
-echo.  format       perform both format-py and lint-js
 echo.  test-py      run python tests
-echo.  lint-py      check for pytho formatting issues via black and flake8
-echo.  format-py    modify python code using black and show flake8 issues
 echo.  test-js      run javascript tests
-echo.  lint-js      check for javascript formatting issues
-echo.  format-js    modify javascript code if possible using linters and formatters
+echo.  lint         check formatting issues
+echo.  lint-py      check python formatting issues
+echo.  lint-js      check javascript formatting issues
+echo.  format       fix formatting issues where possible
+echo.  format-py    fix python formatting issues where possible
+echo.  format-js    fix javascript formatting issues where possible
 goto :eof
 
 :sync-dev
@@ -48,21 +48,21 @@ mkdocs serve -f docs/mkdocs.yml -a localhost:8050
 goto :eof
 
 :lint
-black . --check && flake8 .
+black . --check && ruff .
 npm --prefix .\frontend run lint
 goto :eof
 
 :format
-black . && isort . && flake8 .
+black . && ruff . --fix
 npm --prefix .\frontend run format
 goto :eof
 
 :lint-py
-black . --check && flake8 .
+black . --check && ruff .
 goto :eof
 
 :format-py
-black . && isort -q . && flake8 .
+black . && ruff . --fix
 goto :eof
 
 :lint-js

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,22 +1,7 @@
 [tool.black]
 line-length = 100
-target-version = ['py36', 'py37', 'py38']
-include = '\.pyi?$'
-exclude = '''
-/(
-    \.git,
-  | \.tox,
-  | bin,
-  | docs,
-  | frontend,
-  | logs,
-  | notebooks,
-  | public,
-  | requirements,
-  | scripts/private,
-  | venv
-)/
-'''
+target-version = ['py311']
+extend-exclude = '(frontend|public|scripts/private)'
 
 [tool.isort]
 atomic = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,11 +3,18 @@ line-length = 100
 target-version = ['py311']
 extend-exclude = '(frontend|public|scripts/private)'
 
-[tool.isort]
-atomic = true
-float_to_top = true
-include_trailing_comma = true
-known_third_party = ["bmds"]
-line_length = 100
-multi_line_output = 3
-skip = ["frontend/", "scripts/private/", "venv/"]
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+select = ["F", "E", "W", "I", "UP", "S", "B", "T20", "RUF"]
+ignore = ["E501", "B904", "B007", "S308", "S113", "S314"]
+
+[tool.ruff.isort]
+known-first-party = ["bmds_server"]
+known-third-party = ["bmds"]
+
+[tool.ruff.per-file-ignores]
+"test_*.py" = ["S101", "S106"]
+"scripts/*.py" = ["T201"]
+"**/management/**.py" = ["T201"]
+"**/migrations/**.py" = ["T201"]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,6 @@
 # website
-Django==4.1.7
-django-anymail==9.0
+Django==4.2.0
+django-anymail==9.1
 django-redis==5.2.0
 django-webpack-loader==1.8.0
 djangorestframework==3.14.0
@@ -9,7 +9,7 @@ djangorestframework==3.14.0
 django-reversion==5.0.4
 
 # db
-psycopg2-binary==2.9.5
+psycopg2-binary==2.9.6
 
 # tasks
 celery==5.2.7
@@ -17,4 +17,4 @@ celery==5.2.7
   kombu==5.2.4
 
 plotly==5.13.0
-redis==4.4.2
+redis==4.5.4

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,7 +1,7 @@
 -r base.txt
 
 # debug
-django-debug-toolbar==3.8.1
+django-debug-toolbar==4.0.0
 django_extensions==3.2.1
 
 # docs

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -18,7 +18,7 @@ playwright==1.29.1
 pytest-playwright==0.3.0
 
 # lint and formatting tools
-black==22.12.0
+black==23.3.0
 flake8==6.0.0
 flake8-isort==6.0.0
 isort==5.11.4

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -19,9 +19,7 @@ pytest-playwright==0.3.0
 
 # lint and formatting tools
 black==23.3.0
-flake8==6.0.0
-flake8-isort==6.0.0
-isort==5.11.4
+ruff==0.0.261
 
 # install in editable mode
 -e .

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,11 +28,6 @@ console_scripts =
     manage = bmds_server:manage
     bmds = bmds_server:manage
 
-[flake8]
-exclude = docs,frontend,scripts,venv
-max-line-length = 100
-ignore = E203,E501,W503
-
 [tool:pytest]
 norecursedirs = .git .tox docs static templates
 addopts = --ds=main.settings.testing --reuse-db --nomigrations

--- a/tests/analysis/test_executor.py
+++ b/tests/analysis/test_executor.py
@@ -104,7 +104,6 @@ class TestAnalysisSession:
             data["models"] = {"frequentist_restricted": ["Multistage"]}
             data["dataset_options"][0]["degree"] = 0  # n-1
             session = AnalysisSession.create(data, 0, 0)
-            print(f"{num_doses=} {expected_degree=}")
             _expected_degree(session, expected_degree)
 
         # degree = N -1, bayesian, fixed at degree == 2

--- a/tests/analysis/test_executor.py
+++ b/tests/analysis/test_executor.py
@@ -160,7 +160,6 @@ class TestAnalysisSession:
 
     # disttype 3 Linear and power are not added
     def test_disttype(self, bmds3_complete_continuous):
-
         data = deepcopy(bmds3_complete_continuous)
         data["models"] = {
             "frequentist_restricted": ["Exponential", "Hill", "Linear", "Power"],


### PR DESCRIPTION
Update Django to the latest LTS release, 4.2 ([release notes](https://docs.djangoproject.com/en/4.2/releases/4.2/)). This is a major upgrade from the prior LTS version 3.2.

- update django 3.2.18 -> 4.2 [changes](https://docs.djangoproject.com/en/4.2/releases/4.2/)
- update djangorestframework 3.13.1 -> 3.14.0 [changes](https://www.django-rest-framework.org/community/release-notes/#314x-series)

---

Update to the latest version of black and replace flake8 and isort with [ruff](https://beta.ruff.rs/docs/). These improvements dramatically speed up linting operations, and also allow us to additional linting rule sets including [bandit](https://pypi.org/project/bandit/), [flake8-bugbear](https://pypi.org/project/flake8-bugbear/), and [pyupgrade](https://pypi.org/project/pyupgrade/). Many rules have autofix enabled, so it should require less effort and will be faster.

To integrate with vscode, you'll need to install the [ruff vscode](https://marketplace.visualstudio.com/items?itemName=charliermarsh.ruff) extension. Details described in the `development.md` within this PR.

- Update black 22.3.0 -> 23.3.0 [changes](https://black.readthedocs.io/en/stable/change_log.html)
- Added ruff 0.0.261 [changes](https://github.com/charliermarsh/ruff/releases/tag/v0.0.261)
- Removed flake8, isort, flake8-isort