### PR TITLE
BMDS Desktop settings flag

### DIFF
--- a/bmds_server/analysis/models.py
+++ b/bmds_server/analysis/models.py
@@ -30,10 +30,12 @@ logger = logging.getLogger(__name__)
 
 
 def get_deletion_date(current_deletion_date=None):
-    # if settings.is_desktop here...
-    date = now() + timedelta(days=settings.DAYS_TO_KEEP_ANALYSES)
-    if current_deletion_date:
-        return max(current_deletion_date, date)
+    if not settings.IS_DESKTOP:
+        date = now() + timedelta(days=settings.DAYS_TO_KEEP_ANALYSES)
+        if current_deletion_date:
+            return max(current_deletion_date, date)
+    else:
+        date = None
     return date
 
 

--- a/bmds_server/analysis/models.py
+++ b/bmds_server/analysis/models.py
@@ -30,6 +30,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_deletion_date(current_deletion_date=None):
+    # if settings.is_desktop here...
     date = now() + timedelta(days=settings.DAYS_TO_KEEP_ANALYSES)
     if current_deletion_date:
         return max(current_deletion_date, date)

--- a/bmds_server/analysis/models.py
+++ b/bmds_server/analysis/models.py
@@ -2,7 +2,7 @@ import logging
 import traceback
 import uuid
 from copy import deepcopy
-from datetime import timedelta
+from datetime import datetime, timedelta
 from io import BytesIO
 
 import bmds
@@ -30,13 +30,12 @@ from .schema import AnalysisOutput, AnalysisSessionSchema
 logger = logging.getLogger(__name__)
 
 
-def get_deletion_date(current_deletion_date=None):
-    if not settings.IS_DESKTOP:
-        date = now() + timedelta(days=settings.DAYS_TO_KEEP_ANALYSES)
-        if current_deletion_date:
-            return max(current_deletion_date, date)
-    else:
-        date = None
+def get_deletion_date(current_deletion_date: datetime | None = None) -> datetime | None:
+    if settings.IS_DESKTOP:
+        return None
+    date = now() + timedelta(days=settings.DAYS_TO_KEEP_ANALYSES)
+    if current_deletion_date:
+        return max(current_deletion_date, date)
     return date
 
 

--- a/bmds_server/analysis/validators/session.py
+++ b/bmds_server/analysis/validators/session.py
@@ -16,6 +16,7 @@ class BaseSession(BaseModel):
 
 
 class BaseSessionComplete(BaseSession):
+    # set is_desktop limit to 100, datasets & options
     datasets: conlist(Any, min_items=1, max_items=10)
     models: dict
     options: conlist(Any, min_items=1, max_items=10)

--- a/bmds_server/analysis/validators/session.py
+++ b/bmds_server/analysis/validators/session.py
@@ -20,8 +20,8 @@ max_items = 1000 if settings.IS_DESKTOP else 10
 
 
 class BaseSessionComplete(BaseSession):
-    models: dict
     datasets: conlist(Any, min_items=1, max_items=max_items)
+    models: dict
     options: conlist(Any, min_items=1, max_items=max_items)
 
 

--- a/bmds_server/analysis/validators/session.py
+++ b/bmds_server/analysis/validators/session.py
@@ -1,6 +1,7 @@
 from typing import Any, Literal
 
 import bmds
+from django.conf import settings
 from pydantic import BaseModel, conlist
 
 from ...common.validation import pydantic_validate
@@ -16,10 +17,13 @@ class BaseSession(BaseModel):
 
 
 class BaseSessionComplete(BaseSession):
-    # set is_desktop limit to 100, datasets & options
-    datasets: conlist(Any, min_items=1, max_items=10)
     models: dict
-    options: conlist(Any, min_items=1, max_items=10)
+    if settings.IS_DESKTOP:
+        datasets: conlist(Any, min_items=1, max_items=100)
+        options: conlist(Any, min_items=1, max_items=100)
+    else:
+        datasets: conlist(Any, min_items=1, max_items=10)
+        options: conlist(Any, min_items=1, max_items=10)
 
 
 def validate_session(data: dict, partial: bool = False):

--- a/bmds_server/analysis/validators/session.py
+++ b/bmds_server/analysis/validators/session.py
@@ -16,14 +16,13 @@ class BaseSession(BaseModel):
     dataset_type: bmds.constants.ModelClass
 
 
+max_items = 1000 if settings.IS_DESKTOP else 10
+
+
 class BaseSessionComplete(BaseSession):
     models: dict
-    if settings.IS_DESKTOP:
-        datasets: conlist(Any, min_items=1, max_items=100)
-        options: conlist(Any, min_items=1, max_items=100)
-    else:
-        datasets: conlist(Any, min_items=1, max_items=10)
-        options: conlist(Any, min_items=1, max_items=10)
+    datasets: conlist(Any, min_items=1, max_items=max_items)
+    options: conlist(Any, min_items=1, max_items=max_items)
 
 
 def validate_session(data: dict, partial: bool = False):

--- a/bmds_server/analysis/views.py
+++ b/bmds_server/analysis/views.py
@@ -83,6 +83,7 @@ class AnalysisDetail(DetailView):
             "wordUrl": self.object.get_word_url(),
             "future": settings.ALWAYS_SHOW_FUTURE
             or (self.request.user.is_staff and bool(self.request.GET.get("future"))),
+            "is_desktop": settings.IS_DESKTOP,
         }
         if self.can_edit:
             context["config"]["editSettings"] = {

--- a/bmds_server/main/context_processors.py
+++ b/bmds_server/main/context_processors.py
@@ -13,4 +13,5 @@ def from_settings(request):
         CONTACT_US_EMAIL=settings.CONTACT_US_LINK,
         commit=settings.COMMIT,
         GTM_ID=settings.GTM_ID,
+        IS_DESKTOP=settings.IS_DESKTOP,
     )

--- a/bmds_server/main/settings/base.py
+++ b/bmds_server/main/settings/base.py
@@ -234,3 +234,4 @@ WEBSITE_URI = os.getenv("WEBSITE_URI", "https://example.com")
 INCLUDE_ADMIN = bool(os.environ.get("INCLUDE_ADMIN", "True") == "True")
 
 INCLUDE_BETA_FEATURES = bool(os.environ.get("INCLUDE_BETA", "False") == "True")
+IS_DESKTOP = True

--- a/bmds_server/main/settings/base.py
+++ b/bmds_server/main/settings/base.py
@@ -234,4 +234,4 @@ WEBSITE_URI = os.getenv("WEBSITE_URI", "https://example.com")
 INCLUDE_ADMIN = bool(os.environ.get("INCLUDE_ADMIN", "True") == "True")
 
 INCLUDE_BETA_FEATURES = bool(os.environ.get("INCLUDE_BETA", "False") == "True")
-IS_DESKTOP = False
+IS_DESKTOP = True

--- a/bmds_server/main/settings/base.py
+++ b/bmds_server/main/settings/base.py
@@ -234,4 +234,4 @@ WEBSITE_URI = os.getenv("WEBSITE_URI", "https://example.com")
 INCLUDE_ADMIN = bool(os.environ.get("INCLUDE_ADMIN", "True") == "True")
 
 INCLUDE_BETA_FEATURES = bool(os.environ.get("INCLUDE_BETA", "False") == "True")
-IS_DESKTOP = True
+IS_DESKTOP = False

--- a/bmds_server/main/settings/testing.py
+++ b/bmds_server/main/settings/testing.py
@@ -15,4 +15,6 @@ DATABASES["default"]["TEST"] = {"NAME": "bmds-server-test"}
 PASSWORD_HASHERS = ("django.contrib.auth.hashers.MD5PasswordHasher",)
 
 AUTH_PROVIDERS = {AuthProvider.django, AuthProvider.external}
+
 ALWAYS_SHOW_FUTURE = False
+IS_DESKTOP = False

--- a/frontend/src/components/Main/Actions/Actions.js
+++ b/frontend/src/components/Main/Actions/Actions.js
@@ -56,7 +56,8 @@ class Actions extends Component {
                                     }}
                                 />
                             </div>
-                            {_.isNumber(config.editSettings.deletionDaysUntilDeletion) ? (
+                            {_.isNumber(config.editSettings.deletionDaysUntilDeletion) &&
+                            !mainStore.isDesktop ? (
                                 <>
                                     <a
                                         className="dropdown-item"
@@ -69,9 +70,16 @@ class Actions extends Component {
                                     </p>
                                 </>
                             ) : null}
-                            <a className="dropdown-item" href={config.editSettings.deleteUrl}>
-                                <Icon name="trash3-fill" text="Delete analysis" />
-                            </a>
+                            {!mainStore.isDesktop ? (
+                                <>
+                                    <a
+                                        className="dropdown-item"
+                                        href={config.editSettings.deleteUrl}>
+                                        <Icon name="trash3-fill" text="Delete analysis" />
+                                    </a>
+                                </>
+                            ) : null}
+
                             <div className="dropdown-divider"></div>
                         </>
                     ) : null}

--- a/frontend/src/components/Main/Actions/Actions.js
+++ b/frontend/src/components/Main/Actions/Actions.js
@@ -71,13 +71,9 @@ class Actions extends Component {
                                 </>
                             ) : null}
                             {!mainStore.isDesktop ? (
-                                <>
-                                    <a
-                                        className="dropdown-item"
-                                        href={config.editSettings.deleteUrl}>
-                                        <Icon name="trash3-fill" text="Delete analysis" />
-                                    </a>
-                                </>
+                                <a className="dropdown-item" href={config.editSettings.deleteUrl}>
+                                    <Icon name="trash3-fill" text="Delete analysis" />
+                                </a>
                             ) : null}
 
                             <div className="dropdown-divider"></div>

--- a/frontend/src/components/Main/Actions/Actions.js
+++ b/frontend/src/components/Main/Actions/Actions.js
@@ -75,7 +75,6 @@ class Actions extends Component {
                                     <Icon name="trash3-fill" text="Delete analysis" />
                                 </a>
                             ) : null}
-
                             <div className="dropdown-divider"></div>
                         </>
                     ) : null}

--- a/frontend/src/components/Navigation.js
+++ b/frontend/src/components/Navigation.js
@@ -40,7 +40,7 @@ class Navigation extends Component {
                             Logic
                         </NavLink>
                     </li>
-                    {mainStore.canEdit ? (
+                    {mainStore.canEdit && !mainStore.isDesktop ? (
                         <li className="nav-item ml-auto mr-1">
                             <ShareActions />
                         </li>

--- a/frontend/src/components/Navigation.js
+++ b/frontend/src/components/Navigation.js
@@ -44,7 +44,9 @@ class Navigation extends Component {
                         <li className="nav-item ml-auto mr-1">
                             <ShareActions />
                         </li>
-                    ) : null}
+                    ) : (
+                        <li className="nav-item ml-auto mr-1"></li>
+                    )}
                     <li
                         className={mainStore.canEdit ? "nav-item" : "nav-item ml-auto"}
                         style={{position: "relative"}}>

--- a/frontend/src/components/Navigation.js
+++ b/frontend/src/components/Navigation.js
@@ -48,7 +48,7 @@ class Navigation extends Component {
                             <ShareActions />
                         </li>
                     ) : (
-                        <li className="nav-item ml-auto mr-1"></li>
+                        <span className="ml-auto"></span>
                     )}
                     <li
                         className={mainStore.canEdit ? "nav-item" : "nav-item ml-auto"}

--- a/frontend/src/stores/DataStore.js
+++ b/frontend/src/stores/DataStore.js
@@ -268,7 +268,7 @@ class DataStore {
     }
 
     @computed get canAddNewDataset() {
-        return this.datasets.length < 6;
+        return this.rootStore.mainStore.isDesktop ? true : this.datasets.length < 6;
     }
 
     @computed get hasSelectedDataset() {

--- a/frontend/src/stores/DataStore.js
+++ b/frontend/src/stores/DataStore.js
@@ -268,7 +268,7 @@ class DataStore {
     }
 
     @computed get canAddNewDataset() {
-        const maxItems = this.rootStore.mainStore.isDesktop ? 100 : 6;
+        const maxItems = this.rootStore.mainStore.isDesktop ? 1000 : 6;
         return this.datasets.length < maxItems;
     }
 

--- a/frontend/src/stores/DataStore.js
+++ b/frontend/src/stores/DataStore.js
@@ -268,7 +268,8 @@ class DataStore {
     }
 
     @computed get canAddNewDataset() {
-        return this.rootStore.mainStore.isDesktop ? true : this.datasets.length < 6;
+        const maxItems = this.rootStore.mainStore.isDesktop ? 100 : 6;
+        return this.datasets.length < maxItems;
     }
 
     @computed get hasSelectedDataset() {

--- a/frontend/src/stores/MainStore.js
+++ b/frontend/src/stores/MainStore.js
@@ -281,6 +281,9 @@ class MainStore {
     @computed get isFuture() {
         return this.config.future;
     }
+    @computed get isDesktop() {
+        return this.config.is_desktop;
+    }
     @computed get getExecutionOutputs() {
         return this.executionOutputs;
     }

--- a/frontend/src/stores/OptionsStore.js
+++ b/frontend/src/stores/OptionsStore.js
@@ -50,7 +50,7 @@ class OptionsStore {
     }
 
     @computed get canAddNewOption() {
-        return this.optionsList.length < 6;
+        return this.rootStore.mainStore.isDesktop ? true : this.optionsList.length < 6;
     }
 }
 

--- a/frontend/src/stores/OptionsStore.js
+++ b/frontend/src/stores/OptionsStore.js
@@ -50,7 +50,8 @@ class OptionsStore {
     }
 
     @computed get canAddNewOption() {
-        return this.rootStore.mainStore.isDesktop ? true : this.optionsList.length < 6;
+        const maxItems = this.rootStore.mainStore.isDesktop ? 100 : 6;
+        return this.optionsList.length < maxItems;
     }
 }
 

--- a/frontend/src/stores/OptionsStore.js
+++ b/frontend/src/stores/OptionsStore.js
@@ -50,7 +50,7 @@ class OptionsStore {
     }
 
     @computed get canAddNewOption() {
-        const maxItems = this.rootStore.mainStore.isDesktop ? 100 : 6;
+        const maxItems = this.rootStore.mainStore.isDesktop ? 1000 : 6;
         return this.optionsList.length < maxItems;
     }
 }

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # website
-Django~=4.2.1
+Django~=4.2.3
 django-anymail==9.1
 django-redis==5.2.0
 django-webpack-loader==1.8.0
@@ -17,4 +17,5 @@ celery==5.2.7
   kombu==5.2.4
 
 plotly==5.13.0
+pydantic~=1.10.12
 redis==4.5.4

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # website
-Django~=4.2.3
+Django~=4.2.5
 django-anymail==9.1
 django-redis==5.2.0
 django-webpack-loader==1.8.0
@@ -17,5 +17,4 @@ celery==5.2.7
   kombu==5.2.4
 
 plotly==5.13.0
-pydantic~=1.10.12
 redis==4.5.4

--- a/tests/analysis/test_views.py
+++ b/tests/analysis/test_views.py
@@ -41,7 +41,7 @@ class TestAnalysisDetail:
             "url": f"/analysis/{pk}/",
             "excelUrl": f"/api/v1/analysis/{pk}/excel/",
             "wordUrl": f"/api/v1/analysis/{pk}/word/",
-            "future": True,
+            "future": False,
             "is_desktop": False,
         }
 
@@ -55,7 +55,7 @@ class TestAnalysisDetail:
             "url": f"/analysis/{pk}/",
             "excelUrl": f"/api/v1/analysis/{pk}/excel/",
             "wordUrl": f"/api/v1/analysis/{pk}/word/",
-            "future": True,
+            "future": False,
             "is_desktop": False,
             "editSettings": {
                 "editKey": pw,
@@ -76,9 +76,9 @@ class TestAnalysisDetail:
         analysis = Analysis.objects.get(pk=pk)
         url = analysis.get_absolute_url() + "?future=1"
 
-        # no staff access; recently changed to all access for future
+        # no staff access; no future flag
         response = client.get(url)
-        assert response.context["config"]["future"] is True
+        assert response.context["config"]["future"] is False
 
         # staff access; future flag
         assert client.login(username="admin@bmdsonline.org", password="pw")

--- a/tests/analysis/test_views.py
+++ b/tests/analysis/test_views.py
@@ -41,7 +41,8 @@ class TestAnalysisDetail:
             "url": f"/analysis/{pk}/",
             "excelUrl": f"/api/v1/analysis/{pk}/excel/",
             "wordUrl": f"/api/v1/analysis/{pk}/word/",
-            "future": False,
+            "future": True,
+            "is_desktop": False,
         }
 
         # write view should have edit context
@@ -54,7 +55,8 @@ class TestAnalysisDetail:
             "url": f"/analysis/{pk}/",
             "excelUrl": f"/api/v1/analysis/{pk}/excel/",
             "wordUrl": f"/api/v1/analysis/{pk}/word/",
-            "future": False,
+            "future": True,
+            "is_desktop": False,
             "editSettings": {
                 "editKey": pw,
                 "viewUrl": f"http://testserver/analysis/{pk}/",
@@ -74,9 +76,9 @@ class TestAnalysisDetail:
         analysis = Analysis.objects.get(pk=pk)
         url = analysis.get_absolute_url() + "?future=1"
 
-        # no staff access; no future flag
+        # no staff access; recently changed to all access for future
         response = client.get(url)
-        assert response.context["config"]["future"] is False
+        assert response.context["config"]["future"] is True
 
         # staff access; future flag
         assert client.login(username="admin@bmdsonline.org", password="pw")


### PR DESCRIPTION
Closes #282

Changes:
Added `IS_DESKTOP` flag; default False to preserve existing behavior.

- UI, when `IS_DESKTOP`
  - Hid "Share" button
  - added blank `<li...></li>` to keep "Activities" button justified properly
  - Hid actions/info associated with deletion from "Activities" button
  - overrode the session dataset and options validator to always return `true` 
- Backend/Model
  - set `get_deletion_date()` for the `Analysis` model to return `None`, hopefully there wont be a `None` -> `null` issue
  - allow proper validation of setups with > 6 option sets (100) and >6 datasets (100)