### PR TITLE
add django-browser-reload

### DIFF
--- a/bmds_server/common/middleware.py
+++ b/bmds_server/common/middleware.py
@@ -19,7 +19,7 @@ class RequestLogMiddleware:
             request.method,
             request.path,
             response.status_code,
-            len(response.content),
+            len(getattr(response, "content", "")),
             request.META["REMOTE_ADDR"],
             get_user_id(request.user),
         )

--- a/bmds_server/main/settings/dev.py
+++ b/bmds_server/main/settings/dev.py
@@ -1,8 +1,14 @@
 # flake8: noqa
 from .base import *
 
-INSTALLED_APPS += ("debug_toolbar",)
-MIDDLEWARE += ("debug_toolbar.middleware.DebugToolbarMiddleware",)
+INSTALLED_APPS += (
+    "debug_toolbar",
+    "django_browser_reload",
+)
+MIDDLEWARE += (
+    "debug_toolbar.middleware.DebugToolbarMiddleware",
+    "django_browser_reload.middleware.BrowserReloadMiddleware",
+)
 INTERNAL_IPS = ("127.0.0.1",)
 
 DEBUG = True

--- a/bmds_server/main/urls.py
+++ b/bmds_server/main/urls.py
@@ -80,4 +80,7 @@ if AuthProvider.external in settings.AUTH_PROVIDERS:
 if settings.DEBUG:
     import debug_toolbar
 
-    urlpatterns += (path("__debug__/", include(debug_toolbar.urls)),)
+    urlpatterns += (
+        path("__debug__/", include(debug_toolbar.urls)),
+        path("__reload__/", include("django_browser_reload.urls")),
+    )

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,6 +3,7 @@
 # debug
 django-debug-toolbar==4.0.0
 django_extensions==3.2.1
+django-browser-reload==1.11.0
 
 # docs
 mkdocs-material==9.0.6


### PR DESCRIPTION
Adds [django-browser-reload](https://pypi.org/project/django-browser-reload/) to the developer environment. Whenever making edits to any python code, CSS, or django templates, the page will automatically reload with the updated edits. 