### PR TITLE
add coverage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -70,7 +70,10 @@ jobs:
         DJANGO_DB_PORT: ${{ job.services.postgres.ports[5432] }} # get randomly assigned published port
       run: |
         export "LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH"
-        py.test --vcr-record=none
+        coverage run -m pytest --vcr-record=none
+        coverage html -d coverage_report
+        echo "# Python coverage report" >> $GITHUB_STEP_SUMMARY
+        coverage report --format=markdown >> $GITHUB_STEP_SUMMARY
 
   frontend:
     name: frontend

--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ venv/
 *.py[cod]
 *.sqlite3
 *log
+.coverage
 .env
 .eslintcache
 bmds_server/gitcommit.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,13 @@ line-length = 100
 target-version = ['py311']
 extend-exclude = '(frontend|public|scripts/private)'
 
+[tool.coverage.run]
+omit = [
+    "./bmds_server/main/settings/*",
+    "./tests/*",
+    "./venv/*",
+]
+
 [tool.ruff]
 line-length = 100
 target-version = "py311"

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,11 +8,12 @@ django_extensions==3.2.1
 mkdocs-material==9.0.6
 
 # tests
-pytest==7.2.1
+pytest==7.4.0
 pytest-django==4.5.2
 vcrpy==4.2.1
   urllib3~=1.26.16
 pytest-vcr==1.0.2
+coverage==7.3.0
 
 # integration tests
 playwright==1.29.1


### PR DESCRIPTION
Add a coverage report to our CI pipeline. The report is available under the "checks" menu and shows total coverage of the application from our pytests (not including integration tests).   You can view the report by clicking the "Summary" icon on the Checks tab:

The summary icon:

![image](https://github.com/shapiromatron/bmds-server/assets/999952/82efe9b3-1678-4c89-966b-774c04052b1c)

The HTML report:

![image](https://github.com/shapiromatron/bmds-server/assets/999952/93fccaec-459b-43e3-89f1-47b36e11a951)
