### PR TITLE
293 mt min max datasets

### DIFF
--- a/bmds_server/analysis/validators/datasets.py
+++ b/bmds_server/analysis/validators/datasets.py
@@ -8,10 +8,13 @@ from bmds.datasets import (
     DichotomousDatasetSchema,
     NestedDichotomousDatasetSchema,
 )
+from django.conf import settings
 from django.core.exceptions import ValidationError
-from pydantic import BaseModel, conlist, root_validator
+from pydantic import BaseModel, Field, root_validator
 
 from ...common.validation import pydantic_validate
+
+max_items = 1000 if settings.IS_DESKTOP else 10
 
 
 class MaxDegree(IntEnum):
@@ -80,27 +83,26 @@ class MaxNestedDichotomousDatasetSchema(NestedDichotomousDatasetSchema):
 
 
 class DichotomousDatasets(DatasetValidator):
-    dataset_options: conlist(DichotomousModelOptions, min_items=1, max_items=10)
-    datasets: conlist(MaxDichotomousDatasetSchema, min_items=1, max_items=10)
+    dataset_options: list[DichotomousModelOptions] = Field(min_items=1, max_items=max_items)
+    datasets: list[MaxDichotomousDatasetSchema] = Field(min_items=1, max_items=max_items)
 
 
 class ContinuousDatasets(DatasetValidator):
-    dataset_options: conlist(ContinuousModelOptions, min_items=1, max_items=10)
-    datasets: conlist(
-        MaxContinuousDatasetSchema | MaxContinuousIndividualDatasetSchema,
+    dataset_options: list[ContinuousModelOptions] = Field(min_items=1, max_items=max_items)
+    datasets: list[MaxContinuousDatasetSchema | MaxContinuousIndividualDatasetSchema] = Field(
         min_items=1,
-        max_items=10,
+        max_items=max_items,
     )
 
 
 class NestedDichotomousDataset(DatasetValidator):
-    dataset_options: conlist(NestedDichotomousModelOptions, min_items=1, max_items=10)
-    datasets: conlist(MaxNestedDichotomousDatasetSchema, min_items=1, max_items=10)
+    dataset_options: list[NestedDichotomousModelOptions] = Field(min_items=1, max_items=max_items)
+    datasets: list[MaxNestedDichotomousDatasetSchema] = Field(min_items=1, max_items=max_items)
 
 
 class MultiTumorDatasets(DatasetValidator):
-    dataset_options: conlist(DichotomousModelOptions, min_items=1, max_items=10)
-    datasets: conlist(DichotomousDatasetSchema, min_items=1, max_items=10)
+    dataset_options: list[DichotomousModelOptions] = Field(min_items=1, max_items=max_items)
+    datasets: list[DichotomousDatasetSchema] = Field(min_items=1, max_items=max_items)
 
 
 def validate_datasets(dataset_type: str, datasets: Any, datasetOptions: Any):

--- a/bmds_server/analysis/validators/options.py
+++ b/bmds_server/analysis/validators/options.py
@@ -5,10 +5,13 @@ from bmds.bmds3.constants import DistType
 from bmds.bmds3.types.continuous import ContinuousRiskType
 from bmds.bmds3.types.dichotomous import DichotomousRiskType
 from bmds.bmds3.types.nested_dichotomous import LitterSpecificCovariate
+from django.conf import settings
 from django.core.exceptions import ValidationError
-from pydantic import BaseModel, Field, conlist
+from pydantic import BaseModel, Field
 
 from ...common.validation import pydantic_validate
+
+max_items = 1000 if settings.IS_DESKTOP else 6
 
 
 class DichotomousOption(BaseModel):
@@ -35,15 +38,15 @@ class NestedDichotomousOption(BaseModel):
 
 
 class DichotomousOptions(BaseModel):
-    options: conlist(DichotomousOption, min_items=1, max_items=10)
+    options: list[DichotomousOption] = Field(min_items=1, max_items=max_items)
 
 
 class ContinuousOptions(BaseModel):
-    options: conlist(ContinuousOption, min_items=1, max_items=10)
+    options: list[ContinuousOption] = Field(min_items=1, max_items=max_items)
 
 
 class NestedDichotomousOptions(BaseModel):
-    options: conlist(NestedDichotomousOption, min_items=1, max_items=3)
+    options: list[NestedDichotomousOption] = Field(min_items=1, max_items=max_items)
 
 
 def validate_options(dataset_type: str, data: Any):

--- a/bmds_server/analysis/validators/session.py
+++ b/bmds_server/analysis/validators/session.py
@@ -2,7 +2,7 @@ from typing import Any, Literal
 
 import bmds
 from django.conf import settings
-from pydantic import BaseModel, conlist
+from pydantic import BaseModel, Field
 
 from ...common.validation import pydantic_validate
 
@@ -20,9 +20,9 @@ max_items = 1000 if settings.IS_DESKTOP else 10
 
 
 class BaseSessionComplete(BaseSession):
-    datasets: conlist(Any, min_items=1, max_items=max_items)
+    datasets: list[Any] = Field(min_items=1, max_items=max_items)
     models: dict
-    options: conlist(Any, min_items=1, max_items=max_items)
+    options: list[Any] = Field(min_items=1, max_items=max_items)
 
 
 def validate_session(data: dict, partial: bool = False):

--- a/frontend/src/components/Data/SelectModelType.js
+++ b/frontend/src/components/Data/SelectModelType.js
@@ -11,6 +11,7 @@ import SelectInput from "../common/SelectInput";
 class SelectModelType extends Component {
     render() {
         const {dataStore} = this.props;
+        const isMultitumor = this.props.dataStore.rootStore.mainStore.isMultitumor;
         return (
             <div className="model-type mb-2">
                 <Button
@@ -31,7 +32,9 @@ class SelectModelType extends Component {
                     })}
                 />
                 {dataStore.canAddNewDataset ? null : (
-                    <p className="text-danger">Can have a maximum of 6 datasets per analysis.</p>
+                    <p className="text-danger">
+                        Can have a maximum of {isMultitumor ? 10 : 6} datasets per analysis.
+                    </p>
                 )}
             </div>
         );

--- a/frontend/src/components/Data/SelectModelType.js
+++ b/frontend/src/components/Data/SelectModelType.js
@@ -11,12 +11,10 @@ import SelectInput from "../common/SelectInput";
 class SelectModelType extends Component {
     render() {
         const {dataStore} = this.props;
-        const isMultitumor = this.props.dataStore.rootStore.mainStore.isMultitumor;
         return (
             <div className="model-type mb-2">
                 <Button
                     className="btn btn-primary btn-sm float-right"
-                    title="Can add up to 6 datasets"
                     disabled={!dataStore.canAddNewDataset}
                     icon="plus-circle"
                     text="New"
@@ -33,7 +31,7 @@ class SelectModelType extends Component {
                 />
                 {dataStore.canAddNewDataset ? null : (
                     <p className="text-danger">
-                        Can have a maximum of {isMultitumor ? 10 : 6} datasets per analysis.
+                        Can have a maximum of {dataStore.maxItems} datasets per analysis.
                     </p>
                 )}
             </div>

--- a/frontend/src/components/Main/OptionsForm/OptionsFormList.js
+++ b/frontend/src/components/Main/OptionsForm/OptionsFormList.js
@@ -74,7 +74,7 @@ class OptionsFormList extends Component {
                                     {optionsStore.canEdit ? (
                                         <th>
                                             <Button
-                                                title="Can add up to 6 option sets"
+                                                title="Maximum number of option sets reached."
                                                 className="btn btn-primary"
                                                 disabled={!optionsStore.canAddNewOption}
                                                 onClick={optionsStore.addOptions}
@@ -112,7 +112,8 @@ class OptionsFormList extends Component {
                         </table>
                         {optionsStore.canAddNewOption ? null : (
                             <p className="text-danger">
-                                Can have a maximum of 6 option sets per analysis.
+                                Can have a maximum of {modelType === MODEL_MULTI_TUMOR ? 3 : 6}{" "}
+                                option sets per analysis.
                             </p>
                         )}
                     </form>

--- a/frontend/src/components/Main/OptionsForm/OptionsFormList.js
+++ b/frontend/src/components/Main/OptionsForm/OptionsFormList.js
@@ -112,8 +112,8 @@ class OptionsFormList extends Component {
                         </table>
                         {optionsStore.canAddNewOption ? null : (
                             <p className="text-danger">
-                                Can have a maximum of {modelType === MODEL_MULTI_TUMOR ? 3 : 6}{" "}
-                                option sets per analysis.
+                                Can have a maximum of {optionsStore.maxItems} option sets per
+                                analysis.
                             </p>
                         )}
                     </form>

--- a/frontend/src/stores/DataStore.js
+++ b/frontend/src/stores/DataStore.js
@@ -267,13 +267,15 @@ class DataStore {
             .map(d => d.dataset);
     }
 
-    @computed get canAddNewDataset() {
-        const maxItems = this.rootStore.mainStore.isDesktop
+    @computed get maxItems() {
+        return this.rootStore.mainStore.isDesktop
             ? 1000
             : this.rootStore.mainStore.isMultitumor
             ? 10
             : 6;
-        return this.datasets.length < maxItems;
+    }
+    @computed get canAddNewDataset() {
+        return this.datasets.length < this.maxItems;
     }
 
     @computed get hasSelectedDataset() {

--- a/frontend/src/stores/DataStore.js
+++ b/frontend/src/stores/DataStore.js
@@ -268,7 +268,11 @@ class DataStore {
     }
 
     @computed get canAddNewDataset() {
-        const maxItems = this.rootStore.mainStore.isDesktop ? 1000 : 6;
+        const maxItems = this.rootStore.mainStore.isDesktop
+            ? 1000
+            : this.rootStore.mainStore.isMultitumor
+            ? 10
+            : 6;
         return this.datasets.length < maxItems;
     }
 

--- a/frontend/src/stores/OptionsStore.js
+++ b/frontend/src/stores/OptionsStore.js
@@ -50,7 +50,11 @@ class OptionsStore {
     }
 
     @computed get canAddNewOption() {
-        const maxItems = this.rootStore.mainStore.isDesktop ? 1000 : 6;
+        const maxItems = this.rootStore.mainStore.isDesktop
+            ? 1000
+            : this.rootStore.mainStore.isMultitumor
+            ? 3
+            : 6;
         return this.optionsList.length < maxItems;
     }
 }

--- a/frontend/src/stores/OptionsStore.js
+++ b/frontend/src/stores/OptionsStore.js
@@ -48,14 +48,15 @@ class OptionsStore {
     @computed get getModelType() {
         return this.rootStore.mainStore.model_type;
     }
-
-    @computed get canAddNewOption() {
-        const maxItems = this.rootStore.mainStore.isDesktop
+    @computed get maxItems() {
+        return this.rootStore.mainStore.isDesktop
             ? 1000
             : this.rootStore.mainStore.isMultitumor
             ? 3
             : 6;
-        return this.optionsList.length < maxItems;
+    }
+    @computed get canAddNewOption() {
+        return this.optionsList.length < this.maxItems;
     }
 }
 


### PR DESCRIPTION
Closes 293

For MS Combo, there be a scientific need to model more than 6 datasets together in a single analysis, where our current limit is 6. This PR increases the limit to 10 datasets (but reduces option sets to 6). 

Also update the backend to allow for differences with `IS_DESKTOP` mode where you can add as much as you want.