### PR TITLE
replace black w/ ruff format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,10 +75,10 @@ lint: lint-py lint-js  ## Check formatting issues
 format: format-py format-js  ## Fix formatting issues where possible
 
 lint-py:  ## Check python formatting issues
-	@black . --check && ruff .
+	@ruff format . --check && ruff .
 
 format-py:  ## Fix python formatting issues where possible
-	@black . && ruff . --fix --show-fixes
+	@ruff format . && ruff . --fix --show-fixes
 
 lint-js:  ## Check javascript formatting issues
 	@npm --prefix ./frontend run lint

--- a/bmds_server/common/git.py
+++ b/bmds_server/common/git.py
@@ -17,10 +17,10 @@ class Commit(BaseModel):
             A Commit instance
         """
         cmd = "git log -1 --format=%H"
-        sha = subprocess.check_output(cmd.split(), cwd=cwd).decode().strip()[:8]
+        sha = subprocess.check_output(cmd.split(), cwd=cwd).decode().strip()[:8]  # noqa: S603
         cmd = "git show -s --format=%ct"
         dt = datetime.fromtimestamp(
-            int(subprocess.check_output(cmd.split(), cwd=cwd).decode().strip())
+            int(subprocess.check_output(cmd.split(), cwd=cwd).decode().strip())  # noqa: S603
         )
         return cls(sha=sha, dt=dt)
 

--- a/make.bat
+++ b/make.bat
@@ -48,21 +48,21 @@ mkdocs serve -f docs/mkdocs.yml -a localhost:8050
 goto :eof
 
 :lint
-black . --check && ruff .
+ruff format . --check && ruff .
 npm --prefix .\frontend run lint
 goto :eof
 
 :format
-black . && ruff . --fix --show-fixes
+ruff format . && ruff . --fix --show-fixes
 npm --prefix .\frontend run format
 goto :eof
 
 :lint-py
-black . --check && ruff .
+ruff format . --check && ruff .
 goto :eof
 
 :format-py
-black . && ruff . --fix --show-fixes
+ruff format . && ruff . --fix --show-fixes
 goto :eof
 
 :lint-js

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,3 @@
-[tool.black]
-line-length = 100
-target-version = ['py311']
-extend-exclude = '(frontend|public|scripts/private)'
-
 [tool.coverage.run]
 omit = [
     "./bmds_server/main/settings/*",
@@ -25,4 +20,4 @@ known-third-party = ["bmds"]
 "test_*.py" = ["S101", "S106"]
 "scripts/*.py" = ["T201"]
 "**/management/**.py" = ["T201"]
-"**/migrations/**.py" = ["T201"]
+"**/migrations/**.py" = ["T201", "RUF012"]

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -21,8 +21,7 @@ playwright==1.29.1
 pytest-playwright==0.3.0
 
 # lint and formatting tools
-black==23.3.0
-ruff==0.0.261
+ruff~=0.1.3
 
 # install in editable mode
 -e .


### PR DESCRIPTION
Remove black and use the new [ruff format](https://astral.sh/blog/the-ruff-formatter) command instead. 

This will require modifications to vscode configuration:

```json
"[python]": {
    "editor.defaultFormatter": "charliermarsh.ruff",
    "editor.formatOnSave": true,
    "editor.codeActionsOnSave": {
        "source.fixAll": true
    }
}
```